### PR TITLE
React Native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "browser": {
     "./middleware.js": "./lib/middleware/index.js",
     "./src/index.js": "./lib/index.js",
+    "./lib-node": "./lib",
     "./lib-node/index.js": "./lib/index.js",
     "./src/request/node-request.js": "./src/request/browser-request.js",
     "./lib/request/node-request.js": "./lib/request/browser-request.js",

--- a/src/middleware/defaultOptionsProcessor.js
+++ b/src/middleware/defaultOptionsProcessor.js
@@ -1,8 +1,12 @@
 const objectAssign = require('object-assign')
 const urlParse = require('url-parse')
 
+const isReactNative = typeof navigator === 'undefined'
+  ? false
+  : navigator.product === 'ReactNative'
+
 const has = Object.prototype.hasOwnProperty
-const defaultOptions = {timeout: 120000}
+const defaultOptions = {timeout: isReactNative ? 60000 : 120000}
 
 module.exports = opts => {
   const options = typeof opts === 'string'

--- a/src/request/browser-request.js
+++ b/src/request/browser-request.js
@@ -11,8 +11,10 @@ const adapter = 'xhr'
 
 module.exports = (context, callback) => {
   const options = context.options
-  const cors = !sameOrigin(win.location.href, options.url)
   const timers = {}
+
+  // Deep-checking window.location because of react native, where `location` doesn't exist
+  const cors = win && win.location && !sameOrigin(win.location.href, options.url)
 
   // Allow middleware to inject a response, for instance in the case of caching or mocking
   const injectedResponse = context.applyMiddleware('interceptRequest', undefined, {


### PR DESCRIPTION
This fixes a couple of issues when attempting to use get-it with React Native.
React Native on Android complains about long timers, so I adjusted the default down to 60s on React Native, which seems acceptable.

