### PR TITLE
Allow promise middleware to only resolve response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ request.use(promise())
 
 // Now you're ready to use the requester:
 request({url: '/projects'})
-  .then(projects => console.log(projects))
+  .then(response => console.log(response.body))
   .catch(err => console.error(err))
 ```
 
@@ -97,12 +97,15 @@ By default, `get-it` will return an object of single-channel event emitters. Thi
 
 ## Promise API
 
+For the most part, you simply have to register the middleware and you should be good to go. Sometimes you only need the response body, in which case you can set the `onlyBody` option to `true`. Otherwise the promise will be resolved with the response object mentioned earlier.
+
 ```js
 const getIt = require('get-it')
-const request = getIt([require('get-it/lib/middleware/promise')])
+const promise = require('get-it/lib/middleware/promise')
+const request = getIt([promise({onlyBody: true})])
 
-request({url: 'http://foo.bar'})
-  .then(res => console.log(res.body))
+request({url: 'http://foo.bar/api/projects'})
+  .then(projects => console.log(projects))
   .catch(err => console.error(err))
 ```
 
@@ -112,7 +115,7 @@ If you are targetting older browsers that do not have a global Promise implement
 require('es6-promise/auto')
 
 const promise = require('get-it/lib/middleware/promise')
-const request = getIt([promise])
+const request = getIt([promise()])
 ```
 
 ### Cancelling promise-based requests
@@ -123,7 +126,7 @@ You can create a cancel token using the `CancelToken.source` factory as shown be
 
 ```js
 const promise = require('get-it/lib/middleware/promise')
-const request = getIt([promise])
+const request = getIt([promise()])
 
 const source = promise.CancelToken.source()
 

--- a/src/middleware/promise.js
+++ b/src/middleware/promise.js
@@ -3,8 +3,8 @@ const Cancel = require('./cancel/Cancel')
 const CancelToken = require('./cancel/CancelToken')
 const isCancel = require('./cancel/isCancel')
 
-const promise = () => {
-  const Promise = global.Promise
+const promise = (options = {}) => {
+  const Promise = options.implementation || global.Promise
   if (!Promise) {
     throw new Error('`Promise` is not available in global scope, and no implementation was passed')
   }
@@ -20,7 +20,9 @@ const promise = () => {
       }
 
       channels.error.subscribe(reject)
-      channels.response.subscribe(resolve)
+      channels.response.subscribe(response => {
+        resolve(options.onlyBody ? response.body : response)
+      })
 
       // Wait until next tick in case cancel has been performed
       setTimeout(() => channels.request.publish(context), 0)

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -16,6 +16,12 @@ describe('promise middleware', function () {
     })
   })
 
+  it('should be able to resolve only the response body', () => {
+    const request = requester([baseUrl, promise({onlyBody: true})])
+    const req = request({url: '/plain-text'})
+    return expect(req).to.eventually.equal('Just some plain text for you to consume')
+  })
+
   testNonIE('should reject network errors', () => {
     const request = requester([baseUrl, promise()])
     const req = request({url: '/permafail'})


### PR DESCRIPTION
As outlined in #9 - allow the promise middleware to resolve only the response body. This is especially useful when paired with the `httpErrors` middleware, as you won't have to check the status code.
