### PR TITLE
fix: improve `fetch` fallback, drop dead IE legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
           - os: ubuntu-latest
             # Test the actively developed version that will become the latest LTS release next October
             node: current
+        # The `build` job already runs the testing suite in ubuntu and lts/*
+        exclude:
+          - os: ubuntu-latest
+            # Test the oldest LTS release of Node that's still receiving bugfixes and security patches, versions older than that have reached End-of-Life
+            node: lts/*
+
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3

--- a/modules.d.ts
+++ b/modules.d.ts
@@ -5,10 +5,6 @@ declare module 'tunnel-agent' {
   export function httpsOverHttps(options: any): any
 }
 
-declare module 'same-origin' {
-  export default function sameOrigin(uri1: string, uri2: string, ieMode?: boolean): boolean
-}
-
 declare module 'create-error-class' {
   interface ErrorClass {
     new (res: any, ctx: any): Error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-it",
-  "version": "8.0.3",
+  "version": "8.0.4-esm.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-it",
-      "version": "8.0.3",
+      "version": "8.0.4-esm.0",
       "license": "MIT",
       "dependencies": {
         "create-error-class": "^3.0.2",
@@ -18,10 +18,8 @@
         "is-plain-object": "^5.0.0",
         "is-retry-allowed": "^2.2.0",
         "is-stream": "^2.0.1",
-        "nano-pubsub": "^2.0.1",
         "parse-headers": "^2.0.5",
         "progress-stream": "^2.0.0",
-        "same-origin": "^0.1.1",
         "tunnel-agent": "^0.6.0",
         "url-parse": "^1.5.10"
       },
@@ -7864,11 +7862,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/nano-pubsub": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-2.0.1.tgz",
-      "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA=="
-    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -11916,11 +11909,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/same-origin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/same-origin/-/same-origin-0.1.1.tgz",
-      "integrity": "sha512-effkSW9cap879l6CVNdwL5iubVz8tkspqgfiqwgBgFQspV7152WHaLzr5590yR8oFgt7E1d4lO09uUhtAgUPoA=="
     },
     "node_modules/semantic-release": {
       "version": "20.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-it",
-  "version": "8.0.3",
+  "version": "8.0.4-fetch.0",
   "description": "Generic HTTP request library for node, browsers and workers",
   "keywords": [
     "request",
@@ -105,10 +105,8 @@
     "is-plain-object": "^5.0.0",
     "is-retry-allowed": "^2.2.0",
     "is-stream": "^2.0.1",
-    "nano-pubsub": "^2.0.1",
     "parse-headers": "^2.0.5",
     "progress-stream": "^2.0.0",
-    "same-origin": "^0.1.1",
     "tunnel-agent": "^0.6.0",
     "url-parse": "^1.5.10"
   },

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -1,9 +1,8 @@
-import pubsub from 'nano-pubsub'
-
 import {processOptions} from './middleware/defaultOptionsProcessor'
 import {validateOptions} from './middleware/defaultOptionsValidator'
 import type {HttpRequest, Middleware, Middlewares, Requester} from './types'
 import middlewareReducer from './util/middlewareReducer'
+import pubsub from './util/pubsub'
 
 const channelNames = ['request', 'response', 'progress', 'error', 'abort']
 const middlehooks = [

--- a/src/util/pubsub.ts
+++ b/src/util/pubsub.ts
@@ -1,0 +1,32 @@
+// Code borrowed from https://github.com/bjoerge/nano-pubsub
+
+export interface Subscriber<Event> {
+  (event: Event): void
+}
+export interface PubSub<Message> {
+  publish: (message: Message) => void
+  subscribe: (subscriber: Subscriber<Message>) => () => void
+}
+
+export default function createPubSub<Message = void>(): PubSub<Message> {
+  const subscribers: {[id: string]: Subscriber<Message>} = Object.create(null)
+  let nextId = 0
+  function subscribe(subscriber: Subscriber<Message>) {
+    const id = nextId++
+    subscribers[id] = subscriber
+    return function unsubscribe() {
+      delete subscribers[id]
+    }
+  }
+
+  function publish(event: Message) {
+    for (const id in subscribers) {
+      subscribers[id](event)
+    }
+  }
+
+  return {
+    publish,
+    subscribe,
+  }
+}

--- a/test-deno/import_map.json
+++ b/test-deno/import_map.json
@@ -4,9 +4,7 @@
     "debug": "https://esm.sh/debug@^4.3.4",
     "form-urlencoded": "https://esm.sh/form-urlencoded@^6.1.0",
     "is-plain-object": "https://esm.sh/is-plain-object@^5.0.0",
-    "nano-pubsub": "https://esm.sh/nano-pubsub@^2.0.1",
     "parse-headers": "https://esm.sh/parse-headers@^2.0.5",
-    "same-origin": "https://esm.sh/same-origin@^0.1.1",
     "url-parse": "https://esm.sh/url-parse@^1.5.10"
   }
 }

--- a/test/abort.test.ts
+++ b/test/abort.test.ts
@@ -7,7 +7,7 @@ import {baseUrl, debugRequest} from './helpers'
 
 describe('aborting requests', () => {
   it('should be able to abort requests', () => {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       const request = getIt([baseUrl, debugRequest])
       const req = request({url: '/delay'})
 
@@ -21,7 +21,7 @@ describe('aborting requests', () => {
       )
 
       setTimeout(() => req.abort.publish(), 15)
-      setTimeout(() => resolve(undefined), 250)
+      setTimeout(resolve, 250)
     })
   })
 })

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -162,7 +162,7 @@ describe(
     })
 
     it('should be able to clone a requester, keeping the same middleware', () =>
-      new Promise((resolve) => {
+      new Promise<void>((resolve) => {
         let i = 0
         const onRequest = () => i++
         const base = getIt([baseUrl, {onRequest}])
@@ -173,7 +173,7 @@ describe(
 
         setTimeout(() => {
           expect(i).to.equal(2, 'two requests should have been initiated')
-          resolve(undefined)
+          resolve()
         }, 15)
       }))
   },

--- a/test/debug.test.ts
+++ b/test/debug.test.ts
@@ -15,14 +15,14 @@ describe('debug middleware', () => {
   })
 
   it('should be able to pass custom logger', () =>
-    new Promise((resolve) => {
+    new Promise<void>((resolve) => {
       const logger = debug({log})
       const request = getIt([baseUrl, logger])
       request({url: '/plain-text'}).response.subscribe(() => resolve(undefined))
     }))
 
   it('should be able to pass custom logger (verbose mode)', () =>
-    new Promise((resolve) => {
+    new Promise<void>((resolve) => {
       const logger = debug({log, verbose: true})
       const request = getIt([baseUrl, logger])
       request({url: '/plain-text'}).response.subscribe(() => resolve(undefined))

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -113,7 +113,8 @@ describe('progress', () => {
           expect(events).to.be.above(0, 'should have received progress events')
           resolve(undefined)
         })
-      })
+      }),
+    {timeout: 10000}
   )
 
   it(

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -4,13 +4,14 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "lib": ["dom"],
 
     // Strict type-checking
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
+    "strictPropertyInitialization": false,
     "noImplicitThis": true,
     "alwaysStrict": true,
 


### PR DESCRIPTION
We already dropped IE support by shipping more modern syntax in `get-it@8`. The IE cleanup in this PR can thus be done as a patch release.

`nano-pubsub` is inlined, for now, until it ships ESM. Just to unblock `@sanity/client`'s migration to 100% ESM.