### PR TITLE
fix: use commonjs for legacy middleware export

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,2 +1,2 @@
 // Necessary for `get-it/middleware` imports to work with setups not setup to be ESM native, like older `jest` configs.
-export * from './dist/middleware'
+module.exports = require('./dist/middleware.cjs')


### PR DESCRIPTION
Older tooling like jest 27 that does not support the `exports`  field of `package.json` usually also has trouble with ESM. I might be missing something (the runtime support matrix is _wild_ after all), but I think the `middleware.js` legacy export file should be using CommonJS and reexporting the CommonJS middleware file.

Let me know if this is _not_ correct.