### PR TITLE
fix: add missing attemptNumber argument to retry option typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type HttpRequest = any
 export interface RetryOptions {
   shouldRetry: (err: any, num: number, options: any) => boolean
   maxRetries?: number
-  retryDelay?: () => number
+  retryDelay?: (attemptNumber: number) => number
 }
 
 /**


### PR DESCRIPTION
Uncovered as part of https://github.com/sanity-io/client/pull/199/files