### PR TITLE
chore(tests): re-enable proxy test

### DIFF
--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -20,8 +20,7 @@ afterAll(() => {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
 })
 
-// @TODO remove the "startsWith(20)" check, tracked here: https://github.com/sanity-io/get-it/pull/125
-describe.runIf(environment === 'node' && !process.versions?.node?.startsWith('20'))(
+describe.runIf(environment === 'node')(
   'proxy',
   () => {
     afterEach(async () => {


### PR DESCRIPTION
This PR will be rebased to check up on `tunnel-agent` and NodeJS v20. Hopefully they'll be friends again well before v20 is scheduled to be the new LTS.