### PR TITLE
chore(tests): add failing test for sync error with promise api

### DIFF
--- a/test/promise.test.ts
+++ b/test/promise.test.ts
@@ -17,6 +17,12 @@ describe(
       })
     })
 
+    it('should propagate any request error on the returned promise', async () => {
+      const request = getIt([promise()])
+      const req = request({url: 'invalid://url'})
+      await expect(req).rejects.toThrowError(Error)
+    })
+
     it('should be able to resolve only the response body', async () => {
       const request = getIt([baseUrl, promise({onlyBody: true})])
       const req = request({url: '/plain-text'})


### PR DESCRIPTION
Note: Work in progress

This adds a failing test that demonstrates that connection errors are not propagated on the promise returned from `request()` when using the promise middleware.

I'll take a stab at fixing this when I can find time for it. At first glance it seems a bit tricky, given that it's thrown from a code path that's applied before the `onReturn` step which is the only step the promise middleware currently concerns itself with. Any pointers as to where to look is much appreciated!