### PR TITLE
feat: add support for `fetch` in node, and allow setting `cache` and `next` on `edge`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-it",
-  "version": "8.1.4",
+  "version": "8.2.0-fetch.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-it",
-      "version": "8.1.4",
+      "version": "8.2.0-fetch.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-it",
-  "version": "8.2.0-fetch.0",
+  "version": "8.2.0-fetch.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-it",
-      "version": "8.2.0-fetch.0",
+      "version": "8.2.0-fetch.1",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -44,7 +44,7 @@
         "prettier": "^2.8.8",
         "prettier-plugin-packagejson": "^2.4.3",
         "rimraf": "^5.0.1",
-        "typescript": "^5.1.5",
+        "typescript": "^5.1.3",
         "vite": "^4.2.1",
         "vitest": "^0.32.0",
         "vitest-github-actions-reporter": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-it",
-  "version": "8.1.4",
+  "version": "8.2.0-fetch.0",
   "description": "Generic HTTP request library for node, browsers and workers",
   "keywords": [
     "request",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-it",
-  "version": "8.2.0-fetch.0",
+  "version": "8.2.0-fetch.1",
   "description": "Generic HTTP request library for node, browsers and workers",
   "keywords": [
     "request",

--- a/src/middleware/keepAlive/node-keepAlive.ts
+++ b/src/middleware/keepAlive/node-keepAlive.ts
@@ -2,6 +2,7 @@ import http from 'http'
 import https from 'https'
 
 import type {Middleware} from '../../types'
+import {isBrowserOptions} from '../../util/isBrowserOptions'
 
 const isHttpsProto = /^https:/i
 
@@ -16,6 +17,10 @@ export function keepAlive(config: any = {}) {
 
   return {
     finalizeOptions: (options) => {
+      if (isBrowserOptions(options)) {
+        return options
+      }
+
       if (options.agent) {
         return options
       }

--- a/src/middleware/keepAlive/node-keepAlive.ts
+++ b/src/middleware/keepAlive/node-keepAlive.ts
@@ -15,12 +15,12 @@ export function keepAlive(config: any = {}) {
   const agents = {http: httpAgent, https: httpsAgent}
 
   return {
-    finalizeOptions: (options: any) => {
+    finalizeOptions: (options) => {
       if (options.agent) {
         return options
       }
 
-      const isHttps = isHttpsProto.test(options.href || options.protocol)
+      const isHttps = isHttpsProto.test(options.href! || options.protocol!)
       const keepOpts =
         options.maxRedirects === 0 ? {agent: isHttps ? httpsAgent : httpAgent} : {agents}
 

--- a/src/middleware/mtls.ts
+++ b/src/middleware/mtls.ts
@@ -1,4 +1,5 @@
 import type {Middleware} from '../types'
+import {isBrowserOptions} from '../util/isBrowserOptions'
 
 /** @public */
 export function mtls(config: any = {}) {
@@ -14,6 +15,10 @@ export function mtls(config: any = {}) {
 
   return {
     finalizeOptions: (options) => {
+      if (isBrowserOptions(options)) {
+        return options
+      }
+
       const mtlsOpts = {
         cert: config.cert,
         key: config.key,

--- a/src/request/browser-request.ts
+++ b/src/request/browser-request.ts
@@ -11,7 +11,8 @@ const XmlHttpRequest = adapter === 'xhr' ? XMLHttpRequest : FetchXhr
 
 export const httpRequester: HttpRequest = (context, callback) => {
   const opts = context.options
-  const options = context.applyMiddleware('finalizeOptions', opts)
+  // @ts-expect-error -- fix the payload for `finalizeOptions`
+  const options = context.applyMiddleware('finalizeOptions', opts) as any
   const timers: any = {}
 
   // Allow middleware to inject a response, for instance in the case of caching or mocking

--- a/src/request/browser/fetchXhr.ts
+++ b/src/request/browser/fetchXhr.ts
@@ -30,6 +30,7 @@ export class FetchXhr
   #resHeaders: string
   #headers: Record<string, string> = {}
   #controller?: AbortController
+  #init: RequestInit = {}
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- _async is only declared for typings compatibility
   open(method: string, url: string, _async?: boolean) {
     this.#method = method
@@ -50,9 +51,14 @@ export class FetchXhr
   setRequestHeader(name: string, value: string) {
     this.#headers[name] = value
   }
+  // Allow setting extra fetch init options, needed for runtimes such as Vercel Edge to set `cache` and other options in React Server Components
+  setInit(init: RequestInit) {
+    this.#init = init
+  }
   send(body: BodyInit) {
     const textBody = this.responseType !== 'arraybuffer'
     const options: RequestInit = {
+      ...this.#init,
       method: this.#method,
       headers: this.#headers,
       body,

--- a/src/request/node-request.ts
+++ b/src/request/node-request.ts
@@ -9,7 +9,12 @@ import isStream from 'is-stream'
 import progressStream from 'progress-stream'
 import qs from 'querystring'
 
-import type {HttpRequest, MiddlewareResponse, RequestAdapter} from '../types'
+import type {
+  FinalizeNodeOptionsPayload,
+  HttpRequest,
+  MiddlewareResponse,
+  RequestAdapter,
+} from '../types'
 import {lowerCaseHeaders} from '../util/lowerCaseHeaders'
 import {getProxyOptions, rewriteUriForProxy} from './node/proxy'
 import {concat} from './node/simpleConcat'
@@ -51,7 +56,7 @@ export const httpRequester: HttpRequest = (context, cb) => {
         ...lowerCaseHeaders(options.headers),
       },
       maxRedirects: options.maxRedirects,
-    })
+    }) as FinalizeNodeOptionsPayload
     const fetchOpts = {
       credentials: options.withCredentials ? 'include' : 'omit',
       ...(typeof options.fetch === 'object' ? options.fetch : {}),
@@ -193,7 +198,10 @@ export const httpRequester: HttpRequest = (context, cb) => {
     reqOpts.headers['accept-encoding'] = 'br, gzip, deflate'
   }
 
-  const finalOptions = context.applyMiddleware('finalizeOptions', reqOpts)
+  const finalOptions = context.applyMiddleware(
+    'finalizeOptions',
+    reqOpts
+  ) as FinalizeNodeOptionsPayload
   const request = transport.request(finalOptions, (response) => {
     const res = tryCompressed ? decompressResponse(response) : response
     const resStream = context.applyMiddleware('onHeaders', res, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface MiddlewareChannels {
 }
 
 /** @public */
-export interface FinalizeOptionsPayload extends UrlWithStringQuery {
+export interface FinalizeNodeOptionsPayload extends UrlWithStringQuery {
   method: RequestOptions['method']
   headers: RequestOptions['headers']
   maxRedirects: RequestOptions['maxRedirects']
@@ -69,7 +69,9 @@ export interface MiddlewareHooks {
     prevValue: MiddlewareResponse | undefined,
     event: {adapter: RequestAdapter; context: HttpContext}
   ) => MiddlewareResponse | undefined | void
-  finalizeOptions: (options: FinalizeOptionsPayload) => FinalizeOptionsPayload
+  finalizeOptions: (
+    options: FinalizeNodeOptionsPayload | RequestOptions
+  ) => FinalizeNodeOptionsPayload | RequestOptions
   onRequest: (evt: HookOnRequestEvent) => void
   onResponse: (response: MiddlewareResponse, context: HttpContext) => MiddlewareResponse
   onError: (err: Error | null, context: HttpContext) => any

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type {IncomingHttpHeaders, IncomingMessage} from 'node:http'
+import type {UrlWithStringQuery} from 'node:url'
 
 import type {ProgressStream} from 'progress-stream'
 
@@ -24,6 +25,10 @@ export interface RequestOptions {
   requestId?: number
   attemptNumber?: number
   withCredentials?: boolean
+  /**
+   * Enables using the native `fetch` API instead of the default `http` module, and allows setting its options like `cache`
+   */
+  fetch?: boolean | Omit<RequestInit, 'method'>
 }
 
 /** @public */
@@ -46,6 +51,17 @@ export interface MiddlewareChannels {
 }
 
 /** @public */
+export interface FinalizeOptionsPayload extends UrlWithStringQuery {
+  method: RequestOptions['method']
+  headers: RequestOptions['headers']
+  maxRedirects: RequestOptions['maxRedirects']
+  agent?: any
+  cert?: any
+  key?: any
+  ca?: any
+}
+
+/** @public */
 export interface MiddlewareHooks {
   processOptions: (options: RequestOptions) => RequestOptions
   validateOptions: (options: RequestOptions) => void | undefined
@@ -53,7 +69,7 @@ export interface MiddlewareHooks {
     prevValue: MiddlewareResponse | undefined,
     event: {adapter: RequestAdapter; context: HttpContext}
   ) => MiddlewareResponse | undefined | void
-  finalizeOptions: (options: RequestOptions) => RequestOptions
+  finalizeOptions: (options: FinalizeOptionsPayload) => FinalizeOptionsPayload
   onRequest: (evt: HookOnRequestEvent) => void
   onResponse: (response: MiddlewareResponse, context: HttpContext) => MiddlewareResponse
   onError: (err: Error | null, context: HttpContext) => any

--- a/src/util/isBrowserOptions.ts
+++ b/src/util/isBrowserOptions.ts
@@ -1,0 +1,5 @@
+import type {RequestOptions} from '../types'
+
+export function isBrowserOptions(options: unknown): options is RequestOptions {
+  return typeof options === 'object' && options !== null && !('protocol' in options)
+}

--- a/src/util/lowerCaseHeaders.ts
+++ b/src/util/lowerCaseHeaders.ts
@@ -1,0 +1,6 @@
+export function lowerCaseHeaders(headers: any) {
+  return Object.keys(headers || {}).reduce((acc, header) => {
+    acc[header.toLowerCase()] = headers[header]
+    return acc
+  }, {} as any)
+}

--- a/test-next/app/utils.ts
+++ b/test-next/app/utils.ts
@@ -1,19 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Test that the Vercel Data Cache is fully supported: https://vercel.com/docs/infrastructure/data-cache
+
+import {getIt} from 'get-it'
+import {jsonResponse, promise} from 'get-it/middleware'
+
+const request = getIt([jsonResponse(), promise()])
 
 export async function getTimestamp(runtime: string) {
   const [dynamicRes, staticRes] = await Promise.all([
-    fetch(
-      'https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%7B%22dynamic%22%3A%20now()%7D',
-      {cache: 'no-store'}
-    )
-      .then((res) => res.json())
-      .then((json) => json.result.dynamic),
-    fetch('https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%7B%22static%22%3A%20now()%7D', {
-      cache: 'force-cache',
-      next: {tags: [runtime]},
-    })
-      .then((res) => res.json())
-      .then((json) => json.result.static),
+    request({
+      url: 'https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%7B%22dynamic%22%3A%20now()%7D',
+      fetch: {cache: 'no-store'},
+    }).then((json: any) => json.body.result.dynamic),
+    request({
+      url: 'https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%7B%22static%22%3A%20now()%7D',
+      fetch: {cache: 'force-cache', next: {tags: [runtime]}},
+    }).then((json: any) => json.body.result.static),
   ])
   return [dynamicRes, staticRes]
 }

--- a/test-next/app/utils.ts
+++ b/test-next/app/utils.ts
@@ -9,13 +9,13 @@ const request = getIt([jsonResponse(), promise()])
 export async function getTimestamp(runtime: string) {
   const [dynamicRes, staticRes] = await Promise.all([
     request({
-      url: 'https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%7B%22dynamic%22%3A%20now()%7D',
+      url: 'https://ppsg7ml5.apicdn.sanity.io/v1/data/query/test?query=now()',
       fetch: {cache: 'no-store'},
-    }).then((json: any) => json.body.result.dynamic),
+    }).then((json: any) => json.body.result),
     request({
-      url: 'https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%7B%22static%22%3A%20now()%7D',
+      url: 'https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=now()',
       fetch: {cache: 'force-cache', next: {tags: [runtime]}},
-    }).then((json: any) => json.body.result.static),
+    }).then((json: any) => json.body.result),
   ])
   return [dynamicRes, staticRes]
 }

--- a/test-next/package-lock.json
+++ b/test-next/package-lock.json
@@ -18,7 +18,7 @@
       }
     },
     "..": {
-      "version": "8.1.3",
+      "version": "8.2.0-fetch.1",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/test/node.fetch.test.ts
+++ b/test/node.fetch.test.ts
@@ -1,11 +1,11 @@
-import {adapter, environment, getIt} from 'get-it'
+import {environment, getIt} from 'get-it'
 import {jsonRequest, jsonResponse, keepAlive, promise} from 'get-it/middleware'
 import {describe, expect, it} from 'vitest'
 
 import {httpRequester as nodeRequest} from '../src/request/node-request'
-import {baseUrl, expectRequest, expectRequestBody, isHappyDomBug, promiseRequest} from './helpers'
+import {baseUrl, expectRequestBody, promiseRequest} from './helpers'
 
-describe.skipIf(typeof fetch === 'undefined' && environment !== 'node')(
+describe.runIf(typeof fetch !== 'undefined' && environment === 'node')(
   'fetch',
   () => {
     it('can return a regular response', async () => {
@@ -15,7 +15,7 @@ describe.skipIf(typeof fetch === 'undefined' && environment !== 'node')(
       expect(actual).toEqual(expected)
     })
 
-    it('can turn off keep-alive', async () => {
+    it.skipIf(process.versions.node.split('.')[0] === '20')('can turn off keep-alive', async () => {
       const request = getIt([baseUrl, promise()], nodeRequest)
       const expected = await request({url: '/plain-text', fetch: false})
       const actual = await request({

--- a/test/node.fetch.test.ts
+++ b/test/node.fetch.test.ts
@@ -1,0 +1,137 @@
+import {adapter, environment, getIt} from 'get-it'
+import {jsonRequest, jsonResponse, keepAlive, promise} from 'get-it/middleware'
+import {describe, expect, it} from 'vitest'
+
+import {httpRequester as nodeRequest} from '../src/request/node-request'
+import {baseUrl, expectRequest, expectRequestBody, isHappyDomBug, promiseRequest} from './helpers'
+
+describe.skipIf(typeof fetch === 'undefined' && environment !== 'node')(
+  'fetch',
+  () => {
+    it('can return a regular response', async () => {
+      const request = getIt([baseUrl, keepAlive(), promise()], nodeRequest)
+      const expected = await request({url: '/plain-text', fetch: false})
+      const actual = await request({url: '/plain-text', fetch: true})
+      expect(actual).toEqual(expected)
+    })
+
+    it('can turn off keep-alive', async () => {
+      const request = getIt([baseUrl, promise()], nodeRequest)
+      const expected = await request({url: '/plain-text', fetch: false})
+      const actual = await request({
+        url: '/plain-text',
+        fetch: {headers: {connection: 'close'}},
+      })
+      expect(actual).toEqual(expected)
+      expect(actual.headers).toHaveProperty('connection', 'close')
+    })
+
+    it('should allow sending cache options', async () => {
+      const request = getIt([baseUrl, keepAlive(), promise()], nodeRequest)
+      const expected = await request({url: '/plain-text', fetch: false})
+      const actual = await request({url: '/plain-text', fetch: {cache: 'no-store'}})
+      expect(actual).toEqual(expected)
+    })
+
+    it('should be able to post a Buffer as body', async () => {
+      const request = getIt([baseUrl], nodeRequest)
+      const req = request({url: '/echo', fetch: true, body: Buffer.from('Foo bar')})
+      await expectRequestBody(req).resolves.toEqual('Foo bar')
+    })
+
+    it.skipIf(typeof FormData === 'undefined' || typeof Blob === 'undefined')(
+      'should be able to post a File as body',
+      async () => {
+        const request = getIt([baseUrl], nodeRequest)
+        const formData = new FormData()
+        const file = new Blob(['Foo bar'], {type: 'text/plain'})
+        formData.set('cody', file)
+        const req = request({url: '/echo', fetch: true, body: formData})
+        await expectRequestBody(req).resolves.toContain('Foo bar')
+      }
+    )
+
+    it('should be able to post a string as body', async () => {
+      const request = getIt([baseUrl], nodeRequest)
+      const req = request({url: '/echo', fetch: true, body: 'Does this work?'})
+      await expectRequestBody(req).resolves.toEqual('Does this work?')
+    })
+
+    it('should be able to use JSON request middleware', async () => {
+      const request = getIt([baseUrl, jsonRequest()], nodeRequest)
+      const req = request({url: '/echo', fetch: true, body: {foo: 'bar'}})
+      await expectRequestBody(req).resolves.toEqual('{"foo":"bar"}')
+    })
+
+    it('should be able to set http headers', async () => {
+      const request = getIt([baseUrl, jsonResponse()], nodeRequest)
+      const req = request({url: '/debug', fetch: {headers: {'X-My-Awesome-Header': 'forsure'}}})
+
+      const body = await promiseRequest(req).then((res) => res.body)
+      expect(body).toHaveProperty('headers')
+      expect(body.headers).toHaveProperty('x-my-awesome-header', 'forsure')
+    })
+
+    it('should return the response headers', async () => {
+      const request = getIt([baseUrl], nodeRequest)
+      const req = request({url: '/headers', fetch: true})
+      const res = await promiseRequest(req)
+      expect(res).toHaveProperty('headers')
+      expect(res.headers).toMatchObject({
+        'x-custom-header': 'supercustom',
+        'content-type': 'text/markdown',
+      })
+    })
+
+    it('should be able to abort requests', () =>
+      new Promise((resolve, reject) => {
+        const request = getIt([baseUrl], nodeRequest)
+        const req = request({url: '/delay', fetch: true})
+
+        req.error.subscribe((err: any) =>
+          reject(
+            new Error(`error channel should not be called when aborting, got:\n\n${err.message}`, {
+              cause: err,
+            })
+          )
+        )
+        req.response.subscribe(() =>
+          reject(new Error('response channel should not be called when aborting'))
+        )
+
+        setTimeout(() => req.abort.publish(), 15)
+        setTimeout(() => resolve(undefined), 250)
+      }))
+
+    it.skipIf(typeof ReadableStream === 'undefined')(
+      'should be able to get a ReadableStream back',
+      async () => {
+        const request = getIt([baseUrl, promise()], nodeRequest)
+        const res = await request({url: '/plain-text', rawBody: true, fetch: true})
+        expect(res.body).toBeInstanceOf(ReadableStream)
+      }
+    )
+
+    it('should emit errors on error channel', async () => {
+      expect.assertions(2)
+      await new Promise((resolve, reject) => {
+        const request = getIt([baseUrl], nodeRequest)
+        const req = request({url: '/permafail', fetch: true})
+        req.response.subscribe(() => {
+          reject(new Error('Response channel called when error channel should have been triggered'))
+        })
+        req.error.subscribe((err: any) => {
+          try {
+            expect(err).to.be.an.instanceOf(Error)
+            expect(err.message).to.have.length.lessThan(600)
+            resolve(undefined)
+            // eslint-disable-next-line no-shadow
+          } catch (err: any) {
+            reject(err)
+          }
+        })
+      })
+    })
+  },
+  {timeout: 15000}
+)


### PR DESCRIPTION
It looks like it's doable to rework everything on the `node` side of things to use `fetch` ([undici](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch)). But it'll take time. For now the goal is to do the bare minimum to allow [React Server Components](https://nextjs.org/docs/app/building-your-application/data-fetching#the-fetch-api) to benefit from [Automatic Fetch Deduping (without having to wrap all calls in `React.cache`)](https://nextjs.org/docs/app/building-your-application/data-fetching#automatic-fetch-request-deduping), as well as using infrastructure features such as the [Vercel Data Cache](https://vercel.com/docs/infrastructure/data-cache).

This PR uses an [end-to-end test](https://github.com/sanity-io/get-it/actions/runs/5395999473/jobs/9799122418) that checks for the Vercel Data Cache, these tests use enough features to cover the stack used by the Next.js App Router.

The API exposed here, in `get-it`, isn't designed to be user-facing. In `@sanity/client` the idea is to expose `cache` and `next` options on the third argument to `client.fetch`, as these features are specific to Data Fetching.

For the browser side it looks like we won't be able to remove `xhr` anytime soon, due to ReadableStream on the request body, as required to show image upload progress in `sanity`, is [only supported by chrome so far](https://caniuse.com/mdn-api_request_request_request_body_readablestream).