### PR TITLE
fix: remove node ESM wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-it",
-  "version": "8.3.1",
+  "version": "8.3.2-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-it",
-      "version": "8.3.1",
+      "version": "8.3.2-canary.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-it",
-  "version": "8.3.1",
+  "version": "8.3.2-canary.0",
   "description": "Generic HTTP request library for node, browsers and workers",
   "keywords": [
     "request",
@@ -32,10 +32,6 @@
       "worker": "./dist/index.browser.js",
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
-      "node": {
-        "import": "./dist/index.cjs.js",
-        "require": "./dist/index.cjs"
-      },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
@@ -51,10 +47,6 @@
       "worker": "./dist/middleware.browser.js",
       "source": "./src/middleware.ts",
       "require": "./dist/middleware.cjs",
-      "node": {
-        "import": "./dist/middleware.cjs.js",
-        "require": "./dist/middleware.cjs"
-      },
       "import": "./dist/middleware.js",
       "default": "./dist/middleware.js"
     },

--- a/test-deno/import_map.json
+++ b/test-deno/import_map.json
@@ -1,8 +1,14 @@
 {
   "imports": {
-    "create-error-class": "https://esm.sh/create-error-class@^3.0.2",
     "debug": "https://esm.sh/debug@^4.3.4",
+    "decompress-response": "https://esm.sh/decompress-response@^7.0.0",
+    "follow-redirects": "https://esm.sh/follow-redirects@^1.15.2",
+    "into-stream": "https://esm.sh/into-stream@^6.0.0",
     "is-plain-object": "https://esm.sh/is-plain-object@^5.0.0",
-    "parse-headers": "https://esm.sh/parse-headers@^2.0.5"
+    "is-retry-allowed": "https://esm.sh/is-retry-allowed@^2.2.0",
+    "is-stream": "https://esm.sh/is-stream@^2.0.1",
+    "parse-headers": "https://esm.sh/parse-headers@^2.0.5",
+    "progress-stream": "https://esm.sh/progress-stream@^2.0.0",
+    "tunnel-agent": "https://esm.sh/tunnel-agent@^0.6.0"
   }
 }

--- a/test-esm/test.cjs
+++ b/test-esm/test.cjs
@@ -20,9 +20,7 @@ test('top-level imports', async (t) => {
     }
     assert.deepEqual(
       Object.keys(middlewares).sort(),
-      Object.keys(await import('get-it/middleware'))
-        .filter((name) => name !== 'default')
-        .sort(),
+      Object.keys(await import('get-it/middleware')).sort(),
       'ESM and CJS exports are not the same',
     )
   })

--- a/test-esm/test.mjs
+++ b/test-esm/test.mjs
@@ -20,12 +20,11 @@ test('top-level imports', async (t) => {
   })
 
   await t.test('get-it/middleware', async () => {
-    const {default: skipDefault, ...namespace} = middlewares
-    for (const [name, middleware] of Object.entries(namespace)) {
+    for (const [name, middleware] of Object.entries(middlewares)) {
       assert.equal(typeof middleware, 'function', `${name} is not a function`)
     }
     assert.deepEqual(
-      Object.keys(namespace).sort(),
+      Object.keys(middlewares).sort(),
       Object.keys(require('get-it/middleware')).sort(),
       'ESM and CJS exports are not the same',
     )


### PR DESCRIPTION
Improves build time, and reduces complexity.

It was runtime tested in native CJS and ESM in Node, by using two separate files:
`runtime.cjs`:
```js
const debug = require('debug')
const decompressResponse = require('decompress-response')
const followRedirects = require('follow-redirects')
const intoStream = require('into-stream')
const isPlainObject = require('is-plain-object')
const isRetryAllowed = require('is-retry-allowed')
const isStream = require('is-stream')
const parseHeaders = require('parse-headers')
const progressStream = require('progress-stream')
const tunnelAgent = require('tunnel-agent')
console.log({
  debug,
  decompressResponse,
  followRedirects,
  intoStream,
  isPlainObject,
  isRetryAllowed,
  isStream,
  parseHeaders,
  progressStream,
  tunnelAgent,
})
```
`runtime.mjs`:
```js
import debugIt from 'debug'
import decompressResponse from 'decompress-response'
import followRedirects from 'follow-redirects'
import intoStream from 'into-stream'
import * as isPlainObject from 'is-plain-object'
import isRetryAllowed from 'is-retry-allowed'
import isStream from 'is-stream'
import parseHeaders from 'parse-headers'
import progressStream from 'progress-stream'
import * as tunnelAgent from 'tunnel-agent'
console.log({
  debugIt,
  decompressResponse,
  followRedirects,
  intoStream,
  isPlainObject,
  isRetryAllowed,
  isStream,
  parseHeaders,
  progressStream,
  tunnelAgent,
})
```

These tests demonstrate that the dependencies we're currently using are safe to use and `get-it` no longer need to use the ESM wrapper pattern.
