### PR TITLE
fix: query string merging in legacy react native versions

### DIFF
--- a/src/middleware/defaultOptionsProcessor.ts
+++ b/src/middleware/defaultOptionsProcessor.ts
@@ -11,14 +11,13 @@ export const processOptions = function processOptions(opts) {
     ...(typeof opts === 'string' ? {url: opts} : opts),
   } satisfies RequestOptions
 
-  // Allow parsing relative URLs by setting the origin to `http://localhost`
-  const {searchParams} = new URL(options.url, 'http://localhost')
-
   // Normalize timeouts
   options.timeout = normalizeTimeout(options.timeout)
 
   // Shallow-merge (override) existing query params
   if (options.query) {
+    const {url, searchParams} = splitUrl(options.url)
+
     for (const [key, value] of Object.entries(options.query)) {
       if (value !== undefined) {
         if (Array.isArray(value)) {
@@ -29,13 +28,13 @@ export const processOptions = function processOptions(opts) {
           searchParams.append(key, value as string)
         }
       }
+
+      // Merge back params into url
+      const search = searchParams.toString()
+      if (search) {
+        options.url = `${url}?${search}`
+      }
     }
-  }
-  // Merge back params into url
-  const [url] = options.url.split('?')
-  const search = searchParams.toString()
-  if (search) {
-    options.url = `${url}?${search}`
   }
 
   // Implicit POST if we have not specified a method but have a body
@@ -44,6 +43,50 @@ export const processOptions = function processOptions(opts) {
 
   return options
 } satisfies MiddlewareHooks['processOptions']
+
+/**
+ * Given a string URL, extracts the query string and URL from each other, and returns them.
+ * Note that we cannot use the `URL` constructor because of old React Native versions which are
+ * majorly broken and returns incorrect results:
+ *
+ * (`new URL('http://foo/?a=b').toString()` == 'http://foo/?a=b/')
+ */
+function splitUrl(url: string): {url: string; searchParams: URLSearchParams} {
+  const qIndex = url.indexOf('?')
+  if (qIndex === -1) {
+    return {url, searchParams: new URLSearchParams()}
+  }
+
+  const base = url.slice(0, qIndex)
+  const qs = url.slice(qIndex + 1)
+  const searchParams = new URLSearchParams(qs)
+
+  // Buggy React Native versions do not implement `size`, so if we have one,
+  // we should be able to use a functioning `URLSearchParams` implementation
+  if (typeof searchParams.size === 'number') {
+    return {url: base, searchParams}
+  }
+
+  // Sanity-check; we do not know of any environment where this is the case,
+  // but if it is, we should not proceed without giving a descriptive error
+  if (typeof decodeURIComponent !== 'function') {
+    throw new Error(
+      'Broken `URLSearchParams` implementation, and `decodeURIComponent` is not defined',
+    )
+  }
+
+  // Another brokenness in React Native: `URLSearchParams` does not accept a string argument,
+  // so we'll have do attempt to destructure the query string ourselves :(
+  const params = new URLSearchParams()
+  for (const pair of qs.split('&')) {
+    const [key, value] = pair.split('=')
+    if (key) {
+      params.append(decodeURIComponent(key), decodeURIComponent(value || ''))
+    }
+  }
+
+  return {url: base, searchParams: params}
+}
 
 function normalizeTimeout(time: RequestOptions['timeout']) {
   if (time === false || time === 0) {

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -178,6 +178,24 @@ describe(
       await expectRequestBody(req).resolves.toHaveProperty('url', '/req-test/debug')
     })
 
+    it('should handle URLs with duplicate query params', async () => {
+      const request = getIt([baseUrl, jsonResponse()])
+      const req = request({url: '/debug?dupe=1&dupe=2&lone=3'})
+      await expectRequestBody(req).resolves.toHaveProperty(
+        'url',
+        '/req-test/debug?dupe=1&dupe=2&lone=3',
+      )
+    })
+
+    it('should append explicitly passed query parameters with existing params in URL', async () => {
+      const request = getIt([baseUrl, jsonResponse()])
+      const req = request({url: '/debug?dupe=a', query: {dupe: 'b', lone: 'c'}})
+      await expectRequestBody(req).resolves.toHaveProperty(
+        'url',
+        '/req-test/debug?dupe=a&dupe=b&lone=c',
+      )
+    })
+
     it('should be able to clone a requester, keeping the same middleware', () =>
       new Promise<void>((resolve) => {
         let i = 0


### PR DESCRIPTION
Pull up a chair.

Some React Native versions have a completely broken `URL` and `URLSearchParams` implementations. The latest issue I came across is that if you pass a URL that includes a query string to the `URL` constructor, it appends a trailing slash and has an empty `searchParams` property.

This creates problems when you also pass a `query` option to the request, which should append those query parameters to the existing URLs. Because the parsed URL has an empty `searchParams`, it will append the new query parameters to an empty object and then encode it, resulting in a URL without the original query parameters.

In other words:
```tsx
request({
  url: 'https://foo.bar/some/path?myQuery=string',
  query: {appendThis: 'forMe'}
})
```

Will result in:
- React Native: `https://foo.bar/some/path?appendThis=forMe`
- Others: `https://foo.bar/some/path?myQuery=string&appendThis=forMe`

This PR attempts to solve this in a way that works for all environments.
I've also moved the URL parsing/manipulation into the `if (options.query)` conditional, as in many cases we do not pass any query parameters and thus do not need to invoke these

Unfortunately could not find a good way of emulating a broken React Native environment without having to make the `URLSearchParams` constructor injectable somehow.