### PR TITLE
fix: query string merging in legacy react native versions

### DIFF
--- a/src/middleware/defaultOptionsProcessor.ts
+++ b/src/middleware/defaultOptionsProcessor.ts
@@ -11,14 +11,13 @@ export const processOptions = function processOptions(opts) {
     ...(typeof opts === 'string' ? {url: opts} : opts),
   } satisfies RequestOptions
 
-  // Allow parsing relative URLs by setting the origin to `http://localhost`
-  const {searchParams} = new URL(options.url, 'http://localhost')
-
   // Normalize timeouts
   options.timeout = normalizeTimeout(options.timeout)
 
   // Shallow-merge (override) existing query params
   if (options.query) {
+    const {url, searchParams} = splitUrl(options.url)
+
     for (const [key, value] of Object.entries(options.query)) {
       if (value !== undefined) {
         if (Array.isArray(value)) {
@@ -29,13 +28,13 @@ export const processOptions = function processOptions(opts) {
           searchParams.append(key, value as string)
         }
       }
+
+      // Merge back params into url
+      const search = searchParams.toString()
+      if (search) {
+        options.url = `${url}?${search}`
+      }
     }
-  }
-  // Merge back params into url
-  const [url] = options.url.split('?')
-  const search = searchParams.toString()
-  if (search) {
-    options.url = `${url}?${search}`
   }
 
   // Implicit POST if we have not specified a method but have a body
@@ -44,6 +43,54 @@ export const processOptions = function processOptions(opts) {
 
   return options
 } satisfies MiddlewareHooks['processOptions']
+
+/**
+ * Given a string URL, extracts the query string and URL from each other, and returns them.
+ * Note that we cannot use the `URL` constructor because of old React Native versions which are
+ * majorly broken and returns incorrect results:
+ *
+ * (`new URL('http://foo/?a=b').toString()` == 'http://foo/?a=b/')
+ */
+function splitUrl(url: string): {url: string; searchParams: URLSearchParams} {
+  const qIndex = url.indexOf('?')
+  if (qIndex === -1) {
+    return {url, searchParams: new URLSearchParams()}
+  }
+
+  const base = url.slice(0, qIndex)
+  const qs = url.slice(qIndex + 1)
+  const searchParams = new URLSearchParams(qs)
+
+  // Buggy React Native versions do not implement `.set()`, so if we have one,
+  // we should be able to use a functioning `URLSearchParams` implementation
+  if (typeof searchParams.set === 'function') {
+    return {url: base, searchParams}
+  }
+
+  // Sanity-check; we do not know of any environment where this is the case,
+  // but if it is, we should not proceed without giving a descriptive error
+  if (typeof decodeURIComponent !== 'function') {
+    throw new Error(
+      'Broken `URLSearchParams` implementation, and `decodeURIComponent` is not defined',
+    )
+  }
+
+  // Another brokenness in React Native: `URLSearchParams` does not accept a string argument,
+  // so we'll have do attempt to destructure the query string ourselves :(
+  const params = new URLSearchParams()
+  for (const pair of qs.split('&')) {
+    const [key, value] = pair.split('=')
+    if (key) {
+      params.append(decodeQueryParam(key), decodeQueryParam(value || ''))
+    }
+  }
+
+  return {url: base, searchParams: params}
+}
+
+function decodeQueryParam(value: string): string {
+  return decodeURIComponent(value.replace(/\+/g, ' '))
+}
 
 function normalizeTimeout(time: RequestOptions['timeout']) {
   if (time === false || time === 0) {

--- a/test/queryStrings.test.ts
+++ b/test/queryStrings.test.ts
@@ -36,4 +36,94 @@ describe('query strings', () => {
     const req = request({url: '/query-string', query})
     await expectRequestBody(req).resolves.toEqual({bar: 'baz'})
   })
+
+  it('should handle URLs with duplicate query params', async () => {
+    const request = getIt([baseUrl, jsonResponse()])
+    const req = request({url: '/debug?dupe=1&dupe=2&lone=3'})
+    await expectRequestBody(req).resolves.toHaveProperty(
+      'url',
+      '/req-test/debug?dupe=1&dupe=2&lone=3',
+    )
+  })
+
+  it('should append explicitly passed query parameters with existing params in URL', async () => {
+    const request = getIt([baseUrl, jsonResponse()])
+    const req = request({url: '/debug?dupe=a', query: {dupe: 'b', lone: 'c'}})
+    await expectRequestBody(req).resolves.toHaveProperty(
+      'url',
+      '/req-test/debug?dupe=a&dupe=b&lone=c',
+    )
+  })
+
+  it('should handle query parameter values with escaped `&`, `=`, and `?` (in uri)', async () => {
+    const request = getIt([baseUrl, jsonResponse(), debugRequest])
+    const req = request({
+      url: '/query-string?and=this%26that&equals=this%3Dthat&question=this%3Fthat',
+    })
+    await expectRequestBody(req).resolves.toEqual({
+      and: 'this&that',
+      equals: 'this=that',
+      question: 'this?that',
+    })
+  })
+
+  it('should handle query parameter values with `&`, `=`, and `?` (in `query` option)', async () => {
+    const request = getIt([baseUrl, jsonResponse(), debugRequest])
+    const req = request({
+      url: '/query-string',
+      query: {and: 'this&that', equals: 'this=that', question: 'this?that'},
+    })
+    await expectRequestBody(req).resolves.toEqual({
+      and: 'this&that',
+      equals: 'this=that',
+      question: 'this?that',
+    })
+  })
+
+  it('should handle query parameter values with `&`, `=`, and `?` (mixed)', async () => {
+    const request = getIt([baseUrl, jsonResponse(), debugRequest])
+    const req = request({
+      url: '/query-string?and=this%26that&question=this%3Fthat',
+      query: {equals: 'this=that'},
+    })
+    await expectRequestBody(req).resolves.toEqual({
+      and: 'this&that',
+      equals: 'this=that',
+      question: 'this?that',
+    })
+  })
+
+  it('should handle query parameter values with double equals (uri)', async () => {
+    const request = getIt([baseUrl, jsonResponse(), debugRequest])
+    const req = request({
+      url: '/query-string?query=_type%20%3D%3D+%22test%22',
+    })
+    await expectRequestBody(req).resolves.toEqual({
+      query: '_type == "test"',
+    })
+  })
+
+  it('should handle query parameter values with double equals (uri + query option)', async () => {
+    const request = getIt([baseUrl, jsonResponse(), debugRequest])
+    const req = request({
+      url: '/query-string?query=_type+%3D%3D%20%22test%22',
+      query: {$type: 'itsa == test'},
+    })
+    await expectRequestBody(req).resolves.toEqual({
+      query: '_type == "test"',
+      $type: 'itsa == test',
+    })
+  })
+
+  it('should handle query parameters with empty values', async () => {
+    const request = getIt([baseUrl, jsonResponse(), debugRequest])
+    const req = request({
+      url: '/query-string?a=',
+      query: {b: ''},
+    })
+    await expectRequestBody(req).resolves.toEqual({
+      a: '',
+      b: '',
+    })
+  })
 })


### PR DESCRIPTION
The [previous PR](https://github.com/sanity-io/get-it/pull/351) had some issues:

- `URLSearchParams.prototype.size` was not implemented in _many_ environments, not only React Native. Bun and Node 16 were two of them. We now check for `.set()`, which more environments _do_ support, but older React Native doesn't. The fact that it took this code path would have been fine, except it had a bug I did not catch with my test coverage 👇 
- The sanity client encodes some query parameters up front and adds them to the URL. To do so, it uses `URLSearchParams`, which encodes spaces as `+`. I was unaware that `decodeURIComponent` did not convert `+` to a space. This meant that `_type == "foo"` got encoded as `_type+%3D%3D+%22foo%22`. When we added the query parameter back to a `URLSearchParams` instance, we used the _half_ decoded string, eg `_type+==+"foo"` instead of `_type == "foo"`, which then gets re-encoded as `_type%2B%3D%3D%2B%22foo%22`, eg the `+` got encoded to `%2B`. Those are, of course, two different things.
