### PR TITLE
ci: move npm config provenance flag to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,13 @@ jobs:
         # e.g. git tags were pushed but it exited before `npm publish`
         if: always()
         env:
+          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       # Should release fail, dry rerun with debug on for richer logs
       - run: npx semantic-release --dry-run --debug
         if: ${{ failure() }}
         env:
+          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "node": ">=14.0.0"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   }
 }


### PR DESCRIPTION
Lifted this from 4eaa5079ea2c87c5fbda1b100895b597bfd3765b as it seemed unrelated to the actual change - figure this is still helpful for preleases for now?