### PR TITLE
fix: react native query string parsing

### DIFF
--- a/src/middleware/defaultOptionsProcessor.ts
+++ b/src/middleware/defaultOptionsProcessor.ts
@@ -59,12 +59,11 @@ function splitUrl(url: string): {url: string; searchParams: URLSearchParams} {
 
   const base = url.slice(0, qIndex)
   const qs = url.slice(qIndex + 1)
-  const searchParams = new URLSearchParams(qs)
 
-  // Buggy React Native versions do not implement `.set()`, so if we have one,
-  // we should be able to use a functioning `URLSearchParams` implementation
-  if (typeof searchParams.set === 'function') {
-    return {url: base, searchParams}
+  // React Native's URL and URLSearchParams are broken, so passing a string to URLSearchParams
+  // does not work, leading to an empty query string. For other environments, this should be enough
+  if (!isReactNative) {
+    return {url: base, searchParams: new URLSearchParams(qs)}
   }
 
   // Sanity-check; we do not know of any environment where this is the case,
@@ -75,8 +74,6 @@ function splitUrl(url: string): {url: string; searchParams: URLSearchParams} {
     )
   }
 
-  // Another brokenness in React Native: `URLSearchParams` does not accept a string argument,
-  // so we'll have do attempt to destructure the query string ourselves :(
   const params = new URLSearchParams()
   for (const pair of qs.split('&')) {
     const [key, value] = pair.split('=')


### PR DESCRIPTION
React Native has a new release out, which implements `.set()` on `URLSearchParams`, but does _not_ implement the ability to pass a string to the constructor. Thus, the previous check broke.

Getting tired of keeping these checks in line, so I figure we may as well just blindly use the dumbest query string behavior for React Native, based on navigator check.

