### PR TITLE
feat: improved request body stream conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,7 @@
       "dependencies": {
         "decompress-response": "^7.0.0",
         "follow-redirects": "^1.15.6",
-        "into-stream": "^6.0.0",
         "is-retry-allowed": "^2.2.0",
-        "is-stream": "^2.0.1",
         "progress-stream": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -7458,6 +7456,8 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -9305,21 +9305,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/into-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -9697,6 +9682,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -15169,6 +15155,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
       "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -105,9 +105,7 @@
   "dependencies": {
     "decompress-response": "^7.0.0",
     "follow-redirects": "^1.15.6",
-    "into-stream": "^6.0.0",
     "is-retry-allowed": "^2.2.0",
-    "is-stream": "^2.0.1",
     "progress-stream": "^2.0.0",
     "tunnel-agent": "^0.6.0"
   },

--- a/test-deno/import_map.json
+++ b/test-deno/import_map.json
@@ -3,9 +3,7 @@
     "debug": "https://esm.sh/debug@^4.3.4",
     "decompress-response": "https://esm.sh/decompress-response@^7.0.0",
     "follow-redirects": "https://esm.sh/follow-redirects@^1.15.2",
-    "into-stream": "https://esm.sh/into-stream@^6.0.0",
     "is-retry-allowed": "https://esm.sh/is-retry-allowed@^2.2.0",
-    "is-stream": "https://esm.sh/is-stream@^2.0.1",
     "parse-headers": "https://esm.sh/parse-headers@^2.0.5",
     "progress-stream": "https://esm.sh/progress-stream@^2.0.0",
     "tunnel-agent": "https://esm.sh/tunnel-agent@^0.6.0"

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,6 +1,6 @@
 import {adapter, environment, getIt} from 'get-it'
 import {jsonRequest, jsonResponse} from 'get-it/middleware'
-import intoStream from 'into-stream'
+import {Readable} from 'stream'
 import {describe, it} from 'vitest'
 
 import {baseUrl, debugRequest, expectRequest, expectRequestBody} from './helpers'
@@ -93,7 +93,7 @@ describe('json middleware', () => {
 
   it.runIf(environment === 'node')('should not serialize streams', async () => {
     const request = getIt([baseUrl, jsonRequest(), jsonResponse(), debugRequest])
-    const body = intoStream('unicorn')
+    const body = Readable.from('unicorn')
     const req = request({url: '/echo', method: 'PUT', body})
     await expectRequestBody(req).resolves.toEqual('unicorn')
   })

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1,6 +1,6 @@
 import {environment, getIt} from 'get-it'
 import {getUri} from 'get-uri'
-import toStream from 'into-stream'
+import {Readable} from 'stream'
 import {describe, expect, it} from 'vitest'
 
 import {concat} from '../src/request/node/simpleConcat'
@@ -12,7 +12,7 @@ describe.runIf(environment === 'node')(
     it('should be able to send a stream to a remote endpoint', async () => {
       const body = 'Just some plain text for you to consume'
       const request = getIt([baseUrl, debugRequest])
-      const req = request({url: '/echo', body: toStream(body)})
+      const req = request({url: '/echo', body: Readable.from(body)})
       await expectRequestBody(req).resolves.toEqual(body)
     })
 
@@ -27,7 +27,7 @@ describe.runIf(environment === 'node')(
     it('does not retry failed requests when using streams', async () => {
       const body = 'Just some plain text for you to consume'
       const request = getIt([baseUrl, debugRequest])
-      const req = request({url: '/fail?n=3', body: toStream(body)})
+      const req = request({url: '/fail?n=3', body: Readable.from(body)})
       await expectRequest(req).rejects.toThrow(Error)
     })
 

--- a/test/urlEncoded.test.ts
+++ b/test/urlEncoded.test.ts
@@ -1,6 +1,6 @@
 import {environment, getIt} from 'get-it'
 import {jsonResponse, urlEncoded} from 'get-it/middleware'
-import intoStream from 'into-stream'
+import {Readable} from 'stream'
 import {describe, it} from 'vitest'
 
 import {baseUrl, debugRequest, expectRequestBody} from './helpers'
@@ -73,7 +73,7 @@ describe.runIf(typeof ArrayBuffer !== 'undefined')('urlEncoded middleware', () =
 
   it.runIf(environment === 'node')('should not serialize streams', () => {
     const request = getIt([baseUrl, urlEncoded(), jsonResponse(), debugRequest])
-    const body = intoStream('unicorn')
+    const body = Readable.from('unicorn')
     const req = request({url: '/echo', method: 'PUT', body})
     return expectRequestBody(req).resolves.toEqual('unicorn')
   })


### PR DESCRIPTION
Removes the `into-stream` in favor of node's `Readable.from` method. Additionally removes `is-stream` because it's implementation is so easily inlinable.

This is regarding [SDX-1326](https://linear.app/sanity/issue/SDX-1326/[cli]-json-body-serialization-when-using-sanity-dataset-import-command).

It seems like there are certain cases where get-it would only send part of the request to the server resulting in the server sending a 400 with an `unexpected EOF` error. It took me a while to find but I've traced it back to this old version of `into-stream`.

Research:
- We currently using `into-stream` v6 which seems to unnecessarily slow down transmission by [splitting up the body into arbitrary chunks??](https://github.com/sindresorhus/into-stream/blob/4e07b9f4f84e59de83f2d6b246d945b3f2362ded/index.js#L74-L77)
- It seems like the author also thought this was weird because the [latest major of this package says](https://github.com/sindresorhus/into-stream/releases/tag/v8.0.0)
  > It no longer chunks up the input if it's a string. This should not really matter as the chunks are not guaranteed to be preserved anyway.
- This new version of `into-stream` is much more simple and mostly forwards the result to [`Readable.from` anyway](https://github.com/sindresorhus/into-stream/blob/dda34410828e22d3bb7f4dcc0b24ebf7847f9824/index.js#L46)
- There may be some differences in the output but it looks like our usage will work fine with `Readable.from`. The only case I can think of that's very different is if `options.body` is a Promise returning a string but I don't think that's a usage within `get-it`. Please do let me know if I missed something.
