### PR TITLE
docs(readme): improve readme, remove outdated sections, clarify `body` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ import {getIt} from 'get-it'
 import {base, jsonResponse, promise} from 'get-it/middleware'
 
 // Now compose the middleware you want to use
-const request = getIt([base('https://api.your.service/v1'), jsonResponse()])
+const request = getIt([
+  base('https://api.your.service/v1'),
+  jsonResponse()
+])
 
 // You can also register middleware using `.use(middleware)`
 request.use(promise())
@@ -100,6 +103,7 @@ For the most part, you simply have to register the middleware and you should be 
 ```js
 import {getIt} from 'get-it'
 import {promise} from 'get-it/middleware'
+
 const request = getIt([promise({onlyBody: true})])
 
 request({url: 'http://foo.bar/api/projects'})
@@ -115,6 +119,7 @@ You can create a cancel token using the `CancelToken.source` factory as shown be
 
 ```js
 import {promise} from 'get-it/middleware'
+
 const request = getIt([promise()])
 
 const source = promise.CancelToken.source()

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ The observable API requires you to pass an Observable-implementation that you wa
 ```js
 import {getIt} from 'get-it'
 import {observable} from 'get-it/middleware'
-import zenObservable from 'zen-observable'
+import {Observable as RxjsObservable} from 'rxjs'
 
 const request = getIt()
 
 request.use(
   observable({
-    implementation: zenObservable,
+    implementation: RxjsObservable,
   }),
 )
 

--- a/README.md
+++ b/README.md
@@ -171,12 +171,6 @@ observer.unsubscribe()
 
 It's important to note that the observable middleware does not only emit `response` objects, but also `progress` events. You should always filter to specify what you're interested in receiving. Every emitted value has a `type` property.
 
-## Upcoming features
-
-- Developer-friendly assertions that are stripped in production to reduce bundle size and performance
-- Authentication (basic)
-- Stream response middleware?
-
 ## Prior art
 
 This module was inspired by the great work of others:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In most larger projects, you'd probably make a `httpClient.js` or similar, where
 - `headers` - Object of HTTP headers to send. Note that cross-origin requests in IE9 will not be able to set these headers.
 - `body` - The request body. If the `jsonRequest` middleware is used, it will serialize to a JSON string before sending. Otherwise, it tries to send whatever is passed to it using the underlying adapter. Supported types:
   - _Browser_: `string`, `ArrayBufferView`, `Blob`, `Document`, `FormData` (deprecated: `ArrayBuffer`)
-  - _Node_: `string`, `buffer`, `ReadStream`
+  - _Node_: `string`, `Buffer`, `Iterable`, `AsyncIterable`, `stream.Readable`
 - `bodySize` - Size of body, in bytes. Only used in Node when passing a `ReadStream` as body, in order for progress events to emit status on upload progress.
 - `timeout` - Timeout in millisecond for the request. Takes an object with `connect` and `socket` properties.
 - `maxRedirects` - Maximum number of redirects to follow before giving up. Note that this is only used in Node, as browsers have built-in redirect handling which cannot be adjusted. Default: `5`
@@ -83,8 +83,9 @@ By default, `get-it` will return an object of single-channel event emitters. Thi
 
 ```js
 {
-  // string (ArrayBuffer or Buffer if `rawBody` is set to `true`)
+  // body is `string` by default. When `rawBody` is set to true, will return `ArrayBuffer` in browsers and `Buffer` in Node.js.
   body: 'Response body'
+  // The final URL, after following redirects (configure `maxRedirects` to change the number of redirects to follow)
   url: 'http://foo.bar/baz',
   method: 'GET',
   statusCode: 200,


### PR DESCRIPTION
While reviewing #446, I discovered some sections of the readme that seem out of date, or could use some clarifications.