### PR TITLE
fix(node): fix eventemitter leak when checking for broken socket

### DIFF
--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -1,0 +1,39 @@
+import {environment, getIt} from 'get-it'
+import {keepAlive} from 'get-it/middleware'
+import {describe, it} from 'vitest'
+
+import {baseUrl, promiseRequest} from './helpers'
+
+describe.runIf(environment === 'node')('socket', () => {
+  process.on('warning', (e) => {
+    if (e.name === 'MaxListenersExceededWarning') {
+      throw e
+    }
+  })
+
+  it(`doesn't leak handlers`, async () => {
+    const request = getIt([baseUrl])
+
+    for (let i = 0; i < 100; i++) {
+      ;(await promiseRequest(request('/remote-port'))).body
+    }
+  })
+
+  it(`doesn't leak handlers, with keep alive`, async () => {
+    const request = getIt([baseUrl, keepAlive()])
+
+    for (let i = 0; i < 100; i++) {
+      ;(await promiseRequest(request('/remote-port'))).body
+    }
+  })
+
+  it(`doesn't leak handlers with many concurrent requests`, async () => {
+    const request = getIt([baseUrl, keepAlive()])
+
+    const promises = []
+    for (let i = 0; i < 1000; i++) {
+      promises.push(promiseRequest(request('/delay')))
+    }
+    await Promise.all(promises)
+  })
+})


### PR DESCRIPTION
Since keep alive keeps the socket around for a longer time, we end up keep adding emitters to the socket since onError is only called if the socket errors. This makes sure we are cleaning up when the response is completed.

Fixes sanity-io/get-it#488