### PR TITLE
fix: regression where inlining `debug` breaks next.js envs on custom babel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-it",
-  "version": "8.6.3",
+  "version": "8.6.4-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-it",
-      "version": "8.6.3",
+      "version": "8.6.4-canary.0",
       "license": "MIT",
       "dependencies": {
         "decompress-response": "^7.0.0",

--- a/package.config.ts
+++ b/package.config.ts
@@ -8,4 +8,9 @@ export default defineConfig({
       import: './dist/index.react-server.js',
     },
   ],
+  // Setting up Terser here to workaround a issue where Next.js fails to import from a ESM file that has a reference to `module.exports` somewhere in the file:
+  // https://github.com/vercel/next.js/issues/57962
+  // By enabling minification the problematic reference is changed so the issue is avoided.
+  // The reason this happens is because we're inlining the `debug` module, which is CJS only. We can't stop inlining this module as it breaks Hydrogen compatibility.
+  minify: true,
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-it",
-  "version": "8.6.3",
+  "version": "8.6.4-canary.2",
   "description": "Generic HTTP request library for node, browsers and workers",
   "keywords": [
     "request",


### PR DESCRIPTION
The change introduced in https://github.com/sanity-io/get-it/commit/18798b607c2a10d07efcb6fee48719b881e891ae causes issues with Next.js repos that also have a custom babel setup (typically by adding a `.babelrc` or `babel.config.js` in the root):
```bash
Attempted import error: 'retry' is not exported from 'get-it/middleware' (imported as 'retry').
```

The reason for this error is this code (from `get-it/dist/middleware.browser.js`, which is the inlined source from `debug`):
```js
var common = setup;
(function (module, exports) {
  /* ... other exports */
  exports.log = console.debug || console.log || (() => {});
  module.exports = common(exports);
})(browser, browser.exports);
```
The `module.exports` reference isn't supported by `next` when it occurs in a ESM file, even though it's inline and perfectly valid JS. [I found a report on their repo but it's been auto-closed without a fix.](https://github.com/vercel/next.js/issues/57962)
For now it seems like the best way to handle this is to just minify the code we publish to npm. If we stop inlining `debug` it would solve `next`, but then Hydrogen would break again as it requires pure ESM libraries, and `debug` is CJS-only 😅 