### PR TITLE
Move @types/{follow-redirects,progress-stream} to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "8.6.4",
       "license": "MIT",
       "dependencies": {
+        "@types/follow-redirects": "^1.14.4",
+        "@types/progress-stream": "^2.0.5",
         "decompress-response": "^7.0.0",
         "follow-redirects": "^1.15.6",
         "is-retry-allowed": "^2.2.0",
@@ -21,9 +23,7 @@
         "@sanity/semantic-release-preset": "^5.0.0",
         "@types/bun": "^1.1.6",
         "@types/debug": "^4.1.10",
-        "@types/follow-redirects": "^1.14.4",
         "@types/node": "^20.8.8",
-        "@types/progress-stream": "^2.0.5",
         "@types/zen-observable": "^0.8.7",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -4084,7 +4084,6 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.4.tgz",
       "integrity": "sha512-GWXfsD0Jc1RWiFmMuMFCpXMzi9L7oPDVwxUnZdg89kDNnqsRfUKXEtUYtA98A6lig1WXH/CYY/fvPW9HuN5fTA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4124,7 +4123,6 @@
       "version": "20.14.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.5.tgz",
       "integrity": "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4139,7 +4137,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/progress-stream/-/progress-stream-2.0.5.tgz",
       "integrity": "sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -17043,8 +17040,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
   },
   "browserslist": "extends @sanity/browserslist-config",
   "dependencies": {
+    "@types/follow-redirects": "^1.14.4",
+    "@types/progress-stream": "^2.0.5",
     "decompress-response": "^7.0.0",
     "follow-redirects": "^1.15.6",
     "is-retry-allowed": "^2.2.0",
@@ -111,9 +113,7 @@
     "@sanity/semantic-release-preset": "^5.0.0",
     "@types/bun": "^1.1.6",
     "@types/debug": "^4.1.10",
-    "@types/follow-redirects": "^1.14.4",
     "@types/node": "^20.8.8",
-    "@types/progress-stream": "^2.0.5",
     "@types/zen-observable": "^0.8.7",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",


### PR DESCRIPTION
I'm getting this error in my project:

```
../../node_modules/.pnpm/get-it@8.6.4_debug@4.3.6/node_modules/get-it/dist/index.d.ts:3:35
Type error: Could not find a declaration file for module 'progress-stream'. '/Users/spencer/path/to/project/node_modules/.pnpm/progress-stream@2.0.0/node_modules/progress-stream/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/progress-stream` if it exists or add a new declaration (.d.ts) file containing `declare module 'progress-stream';`

  1 | import type {IncomingHttpHeaders} from 'http'
  2 | import type {IncomingMessage} from 'http'
> 3 | import type {ProgressStream} from 'progress-stream'
    |                                   ^
  4 | import type {UrlWithStringQuery} from 'url'
  5 |
  6 | /** @public */
 ELIFECYCLE  Command failed with exit code 1.
```

As described on https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies, `@types` packages for dependencies should be included in `dependencies` and not `devDependencies` so they will be installed by consumers.