### PR TITLE
fix: auto-infer proxy if `proxy` option is `undefined`

### DIFF
--- a/src/request/node-request.ts
+++ b/src/request/node-request.ts
@@ -185,9 +185,10 @@ export const httpRequester: HttpRequest = (context, cb) => {
 
   // Handle proxy authorization if present
   if (!tunnel && proxy && proxy.auth && !reqOpts.headers['proxy-authorization']) {
-    const [username, password] = proxy.auth.username
-      ? [proxy.auth.username, proxy.auth.password]
-      : proxy.auth.split(':').map((item: any) => qs.unescape(item))
+    const [username, password] =
+      typeof proxy.auth === 'string'
+        ? proxy.auth.split(':').map((item) => qs.unescape(item))
+        : [proxy.auth.username, proxy.auth.password]
 
     const auth = Buffer.from(`${username}:${password}`, 'utf8')
     const authBase64 = auth.toString('base64')

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface RequestOptions {
   maxRetries?: number
   retryDelay?: (attemptNumber: number) => number
   method?: string
-  proxy?: any
+  proxy?: string | false | null | ProxyOptions
   query?: any
   rawBody?: boolean
   shouldRetry?: any
@@ -34,6 +34,16 @@ export interface RequestOptions {
    * Some frameworks have special behavior for `fetch` when an `AbortSignal` is used, and may want to disable it unless userland specifically opts-in.
    */
   useAbortSignal?: boolean
+}
+
+/**
+ * @public
+ */
+export interface ProxyOptions {
+  host: string
+  port: number
+  protocol?: 'http:' | 'https:'
+  auth?: {username?: string; password?: string}
 }
 
 /** @public */

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -52,6 +52,16 @@ describe.runIf(environment === 'node')('proxy', {timeout: 15000}, () => {
     return expectRequest(req).resolves.toHaveProperty('body', body)
   })
 
+  it('http: should proxy if `proxy` option is `undefined`', async () => {
+    process.env['http_proxy'] = 'http://localhost:4000/'
+
+    const body = 'Just some plain text for you to consume + proxy'
+    const request = getIt([baseUrl, debugRequest])
+
+    const req = request({url: '/plain-text', proxy: undefined})
+    return expectRequest(req).resolves.toHaveProperty('body', body)
+  })
+
   it('http: should support proxy set via env var', async () => {
     const body = 'Just some plain text for you to consume + proxy'
     const request = getIt([baseUrl, debugRequest])


### PR DESCRIPTION
4 years ago, https://github.com/sanity-io/sanity/pull/2661 introduced a change in the `@sanity/client` where the `proxy` request option would always be set - either to an actual value, or to `undefined`. This broke automatic proxying in the client through environment variables (`HTTPS_PROXY` etc) because get-it used an overly pedantic `hasOwnProperty` check instead of checking for some not undefined value.

With this change, we instead automatically infer the proxy if the `proxy` option is either not present, **OR** it is `undefined`. Users can still opt out by setting it to `null` or `false` explicitly.

Also improves on the typescript coverage.