### PR TITLE
feat: improve stacktraces in errors and add RequestOptions.callSiteStack

### DIFF
--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -51,6 +51,12 @@ export function createRequester(initMiddleware: Middlewares, httpRequest: HttpRe
   )
 
   function request(opts: RequestOptions | string) {
+    // Capture a stack trace now before async operations happen, so we can append it to any errors that may be thrown
+    const ownStack = new Error().stack
+    // Or pass in an external stack trace (ex. from @sanity/client) to use instead of ours
+    const externalStack =
+      typeof opts === 'object' && opts.callSiteStack ? opts.callSiteStack : undefined
+
     const onResponse = (reqErr: Error | null, res: MiddlewareResponse, ctx: HttpContext) => {
       let error = reqErr
       let response: MiddlewareResponse | null = res
@@ -72,6 +78,17 @@ export function createRequester(initMiddleware: Middlewares, httpRequest: HttpRe
 
       // Figure out if we should publish on error/response channels
       if (error) {
+        if (error instanceof Error) {
+          // Append the call-site frames so errors can be traced back to the code that initiated the request, not just the internal pipeline.
+          // Prefer an externally provided stack (ex. @sanity/client) over the one captured here inside get-it's request() function.
+          const stack = externalStack || ownStack
+          if (stack) {
+            const callSiteLines = stack.split('\n').slice(externalStack ? 1 : 2)
+            if (callSiteLines.length > 0) {
+              error.stack += '\n' + callSiteLines.join('\n')
+            }
+          }
+        }
         channels.error.publish(error)
       } else if (response) {
         channels.response.publish(response)

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -51,11 +51,11 @@ export function createRequester(initMiddleware: Middlewares, httpRequest: HttpRe
   )
 
   function request(opts: RequestOptions | string) {
-    // Capture a stack trace now before async operations happen, so we can append it to any errors that may be thrown
-    const ownStack = new Error().stack
     // Or pass in an external stack trace (ex. from @sanity/client) to use instead of ours
     const externalStack =
       typeof opts === 'object' && opts.callSiteStack ? opts.callSiteStack : undefined
+    // Capture an error now before async operations happen, but defer stack formatting until an error is actually thrown
+    const ownError = externalStack ? undefined : new Error()
 
     const onResponse = (reqErr: Error | null, res: MiddlewareResponse, ctx: HttpContext) => {
       let error = reqErr
@@ -81,8 +81,10 @@ export function createRequester(initMiddleware: Middlewares, httpRequest: HttpRe
         if (error instanceof Error) {
           // Append the call-site frames so errors can be traced back to the code that initiated the request, not just the internal pipeline.
           // Prefer an externally provided stack (ex. @sanity/client) over the one captured here inside get-it's request() function.
-          const stack = externalStack || ownStack
+          const stack = externalStack || ownError?.stack
           if (stack) {
+            // External stacks come from the actual user call site, so only drop the "Error" header.
+            // Internal stacks also include this request() frame, so drop that as well.
             const callSiteLines = stack.split('\n').slice(externalStack ? 1 : 2)
             if (callSiteLines.length > 0) {
               error.stack += '\n' + callSiteLines.join('\n')

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -51,11 +51,11 @@ export function createRequester(initMiddleware: Middlewares, httpRequest: HttpRe
   )
 
   function request(opts: RequestOptions | string) {
-    // Or pass in an external stack trace (ex. from @sanity/client) to use instead of ours
-    const externalStack =
+    // Or pass in an external error (ex. from @sanity/client) to use its stack instead of ours
+    const externalCallSiteError =
       typeof opts === 'object' && opts.callSiteStack ? opts.callSiteStack : undefined
     // Capture an error now before async operations happen, but defer stack formatting until an error is actually thrown
-    const ownError = externalStack ? undefined : new Error()
+    const ownError = externalCallSiteError ? undefined : new Error()
 
     const onResponse = (reqErr: Error | null, res: MiddlewareResponse, ctx: HttpContext) => {
       let error = reqErr
@@ -81,11 +81,11 @@ export function createRequester(initMiddleware: Middlewares, httpRequest: HttpRe
         if (error instanceof Error) {
           // Append the call-site frames so errors can be traced back to the code that initiated the request, not just the internal pipeline.
           // Prefer an externally provided stack (ex. @sanity/client) over the one captured here inside get-it's request() function.
-          const stack = externalStack || ownError?.stack
-          if (stack) {
+          const stack = externalCallSiteError?.stack || ownError?.stack
+          if (typeof stack === 'string') {
             // External stacks come from the actual user call site, so only drop the "Error" header.
             // Internal stacks also include this request() frame, so drop that as well.
-            const callSiteLines = stack.split('\n').slice(externalStack ? 1 : 2)
+            const callSiteLines = stack.split('\n').slice(externalCallSiteError ? 1 : 2)
             if (callSiteLines.length > 0) {
               error.stack += '\n' + callSiteLines.join('\n')
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,11 @@ export interface RequestOptions {
    * Some frameworks have special behavior for `fetch` when an `AbortSignal` is used, and may want to disable it unless userland specifically opts-in.
    */
   useAbortSignal?: boolean
+  /**
+   * A pre-captured stack trace from the call site that initiated this request.
+   * When provided, this will be appended to error stack traces instead of the stack captured internally.
+   */
+  callSiteStack?: string
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,10 +35,10 @@ export interface RequestOptions {
    */
   useAbortSignal?: boolean
   /**
-   * A pre-captured stack trace from the call site that initiated this request.
+   * A pre-captured Error instance from the call site that initiated this request.
    * When provided, this will be appended to error stack traces instead of the stack captured internally.
    */
-  callSiteStack?: string
+  callSiteStack?: Pick<Error, 'stack'>
 }
 
 /**

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -90,6 +90,15 @@ describe('errors', () => {
     ])
   })
 
+  it('should include call-site stack trace in errors', async () => {
+    const request = getIt([baseUrl, httpErrors()])
+    const req = request({url: '/status?code=400'})
+    const err: any = await new Promise((resolve) => req.error.subscribe(resolve))
+    expect(err).to.be.an.instanceOf(Error)
+    // The call-site stack should include this test file
+    expect(err.stack).to.include('errors.test.ts')
+  })
+
   it.runIf(adapter === 'node')('error object contains remote address when serialized', async () => {
     const request = getIt([baseUrl, httpErrors()])
     const req = request({url: '/status?code=400'})

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -99,6 +99,15 @@ describe('errors', () => {
     expect(err.stack).to.include('errors.test.ts')
   })
 
+  it('should use provided callSiteStack in errors instead of the internal stack', async () => {
+    const request = getIt([baseUrl, httpErrors()])
+    const callSiteStack = {stack: 'Error\n    at myCustomCallSite (custom-call-site.ts:42:13)'}
+    const req = request({url: '/status?code=400', callSiteStack})
+    const err: any = await new Promise((resolve) => req.error.subscribe(resolve))
+    expect(err).to.be.an.instanceOf(Error)
+    expect(err.stack).to.include('myCustomCallSite (custom-call-site.ts:42:13)')
+  })
+
   it.runIf(adapter === 'node')('error object contains remote address when serialized', async () => {
     const request = getIt([baseUrl, httpErrors()])
     const req = request({url: '/status?code=400'})


### PR DESCRIPTION
Related to AIGRO-4516

### Description

Stack traces from get-it have been super hard to debug in my experience, since they never point to the actual function that's starting the request, just a bunch of async internals.

This captures the call stack early in the request process, so that if an error is thrown later, we can append the original stacktrace to the error.

Here's a diff of a stacktrace before/after this change:

```diff
diff --git a/error.txt b/error.txt
index 24db988..8b92cb2 100644
--- a/error.txt
+++ b/error.txt
@@ -1,8 +1,12 @@
 Error: GET-request to http://httpbin.org/status/404 resulted in HTTP 404 NOT FOUND
     at onResponse (/Users/jonah.snider/programming/sanity/get-it/src/middleware/httpErrors.ts:27:17)
     at applyMiddleware (/Users/jonah.snider/programming/sanity/get-it/src/util/middlewareReducer.ts:11:15)
-    at onResponse (/Users/jonah.snider/programming/sanity/get-it/src/createRequester.ts:62:22)
+    at onResponse (/Users/jonah.snider/programming/sanity/get-it/src/createRequester.ts:68:22)
     at <anonymous> (/Users/jonah.snider/programming/sanity/get-it/src/request/node/simpleConcat.ts:8:13)
     at emit (node:events:92:22)
     at endReadableNT (internal:streams/readable:861:50)
     at processTicksAndRejections (native:7:39)
+    at myAppFunction (/Users/jonah.snider/programming/sanity/get-it/test-stack.ts:8:29)
+    at /Users/jonah.snider/programming/sanity/get-it/test-stack.ts:12:7
+    at asyncModuleEvaluation (native:2)
+    at processTicksAndRejections (native:7:39)
```

Previously there was zero mention of the `test-stack.ts` script I was using. With this change it's correctly included as the cause of the error!

Related: https://github.com/svsool/axios-better-stacktrace

### What to review

Would be cool if we didn't need to have `RequestOptions.callSiteStack`, but it wasn't immediately clear to me how to get `@sanity/client` to benefit from this without adding that in. Would appreciate advice here.

See sanity-io/client#1184 for the `@sanity/client` change that accompanies this one.

### Testing

Tested locally with `pnpm link` and confirmed it works.

Also added a unit test
