### PR TITLE
fix: inline `follow-redirects`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,8 @@
       "rangeStrategy": "bump"
     },
     {
-      "matchPackageNames": ["debug", "parse-headers"],
+      "description": "Inlined dependencies, to avoid various ESM/CJS issues as well as package manager peer dependency edge cases",
+      "matchPackageNames": ["debug", "follow-redirects", "parse-headers"],
       "rangeStrategy": "bump",
       "semanticCommitType": "fix"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "8.7.1",
       "license": "MIT",
       "dependencies": {
-        "@types/follow-redirects": "^1.14.4",
         "decompress-response": "^7.0.0",
-        "follow-redirects": "^1.15.11",
         "is-retry-allowed": "^2.2.0",
         "through2": "^4.0.2",
         "tunnel-agent": "^0.6.0"
@@ -23,6 +21,7 @@
         "@sanity/semantic-release-preset": "^5.0.0",
         "@types/bun": "^1.2.17",
         "@types/debug": "^4.1.12",
+        "@types/follow-redirects": "^1.14.4",
         "@types/node": "^20.8.8",
         "@types/through2": "^2.0.41",
         "@types/zen-observable": "^0.8.7",
@@ -34,6 +33,7 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "follow-redirects": "1.15.11",
         "get-uri": "^6.0.4",
         "happy-dom": "^18.0.1",
         "ls-engines": "^0.9.3",
@@ -4190,6 +4190,7 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.4.tgz",
       "integrity": "sha512-GWXfsD0Jc1RWiFmMuMFCpXMzi9L7oPDVwxUnZdg89kDNnqsRfUKXEtUYtA98A6lig1WXH/CYY/fvPW9HuN5fTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4206,6 +4207,7 @@
       "version": "20.19.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.2.tgz",
       "integrity": "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -7434,6 +7436,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -17700,6 +17703,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -102,9 +102,7 @@
   "browserslist": "extends @sanity/browserslist-config",
   "prettier": "@sanity/prettier-config",
   "dependencies": {
-    "@types/follow-redirects": "^1.14.4",
     "decompress-response": "^7.0.0",
-    "follow-redirects": "^1.15.11",
     "is-retry-allowed": "^2.2.0",
     "through2": "^4.0.2",
     "tunnel-agent": "^0.6.0"
@@ -116,6 +114,7 @@
     "@sanity/semantic-release-preset": "^5.0.0",
     "@types/bun": "^1.2.17",
     "@types/debug": "^4.1.12",
+    "@types/follow-redirects": "^1.14.4",
     "@types/node": "^20.8.8",
     "@types/through2": "^2.0.41",
     "@types/zen-observable": "^0.8.7",
@@ -127,6 +126,7 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "follow-redirects": "1.15.11",
     "get-uri": "^6.0.4",
     "happy-dom": "^18.0.1",
     "ls-engines": "^0.9.3",


### PR DESCRIPTION
### Description

The `follow-redirects` package has annoyingly decided to specify `debug` as a `peerDependenciesMeta`, [but not under](https://github.com/follow-redirects/follow-redirects/blob/5e8b8d024e2c76f804a284258e585ecb49a575be/package.json#L45-L49) `peerDependencies`. This leads to a bit of undefined behavior where managers that support `peerDependenciesMeta` can decide to pull in `debug`, but not always (it's optional after all).
`get-it` is a deep dependency that a lot of other libraries rely on. Two of them are very sensitive to `node_modules` duplication:
- `@sanity/client`
- `sanity`

For `@sanity/client` it's sensitive to duplication when it comes to [TypeGen](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen) features, as the `declare module '@sanity/client'` trick only works if the libraries that call `client.fetch` point to the same instance of `@sanity/client` as the typegen.

For `sanity` it's very sensitive to `React.createContext` duplicated chunks, which is a problem we detect at runtime and that can be difficult to resolve on monorepos.
In some cases the only stable [workaround is to use a pnpm hook to remove `peerDependenciesMeta` from `follow-redirects`](https://github.com/sanity-io/next-sanity/blob/370bbfb24ba82f50029f94d177c36a60c6a81969/.pnpmfile.cjs#L2-L5), however such workarounds have other drawbacks (like not being able to leverage renovatebot and similar dependency management automation).

For now the best fix is to inline `follow-redirects`, [that way downstream don't have to deal with the consequences of its less than ideal peer dep spec](https://github.com/follow-redirects/follow-redirects/issues?q=is%3Aissue%20state%3Aclosed%20debug), while the runtime behavior is the same as before.
[We've already done this in the past for deps like `debug`.](https://github.com/sanity-io/get-it/commit/18798b607c2a10d07efcb6fee48719b881e891ae)

### What to review

Missed anything?

### Testing

Existing tests should be enough.