### PR TITLE
fix: move NodeRequestError to own module to avoid heavy transitive imports

### DIFF
--- a/src/middleware/keepAlive.ts
+++ b/src/middleware/keepAlive.ts
@@ -1,7 +1,7 @@
 import type {Middleware} from 'get-it'
 import type {AgentOptions} from 'http'
 
-import {NodeRequestError} from '../request/node-request'
+import {NodeRequestError} from '../request/node-request-error'
 
 type KeepAliveOptions = {
   ms?: number

--- a/src/request/node-request-error.ts
+++ b/src/request/node-request-error.ts
@@ -1,0 +1,12 @@
+import type {ClientRequest} from 'http'
+
+export class NodeRequestError extends Error {
+  request: ClientRequest
+  code?: string | undefined
+
+  constructor(err: NodeJS.ErrnoException, req: any) {
+    super(err.message)
+    this.request = req
+    this.code = err.code
+  }
+}

--- a/src/request/node-request.ts
+++ b/src/request/node-request.ts
@@ -14,6 +14,7 @@ import {getProxyOptions, rewriteUriForProxy} from './node/proxy'
 import {concat} from './node/simpleConcat'
 import {timedOut} from './node/timedOut'
 import * as tunneling from './node/tunnel'
+import {NodeRequestError} from './node-request-error'
 
 /**
  * Taken from:
@@ -24,17 +25,6 @@ const isStream = (stream: any): stream is Stream =>
 
 /** @public */
 export const adapter: RequestAdapter = 'node'
-
-export class NodeRequestError extends Error {
-  request: http.ClientRequest
-  code?: string | undefined
-
-  constructor(err: NodeJS.ErrnoException, req: any) {
-    super(err.message)
-    this.request = req
-    this.code = err.code
-  }
-}
 
 // Reduce a fully fledged node-style response object to
 // something that works in both browser and node environment


### PR DESCRIPTION
### Description

When `./keepAlive` imports just `NodeRequestError` from `./node-request` it ends up pulling in a lot more dependencies than what's strictly needed for that subclass of `Error`.
By putting the error class to its own file, that both `./keepAlive` and `./node-request` can import from we avoid bloating the deps getting pulled into `get-it/middleware`.

### What to review

Missed anything?
Did a prerelease: https://npmdiff.dev/get-it/8.7.1/8.7.1-canary.0/

### Testing

CI tests are sufficient for detecting any regressions here
