### PR TITLE
fix: remove extra "is" in error message

### DIFF
--- a/src/request/browser-request.ts
+++ b/src/request/browser-request.ts
@@ -56,7 +56,7 @@ export const httpRequester: HttpRequest = (context, callback) => {
       onError(
         event instanceof Error
           ? event
-          : new Error(`Request error while attempting to reach is ${options.url}`, {cause: event}),
+          : new Error(`Request error while attempting to reach ${options.url}`, {cause: event}),
       )
     } else {
       onError(


### PR DESCRIPTION
### Description
Fixes a tiny gripe of mine :)

### What to review


### Testing

