### PR TITLE
ci: set up pnpm before updating browserslist db

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
+          cache: pnpm
           node-version: lts/*
       - run: npx update-browserslist-db@latest
       - uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Problem

The [Update Browserslist database](https://github.com/sanity-io/get-it/actions/runs/27175160699/job/80222403259) workflow fails at the `npx update-browserslist-db@latest` step:

```
/bin/sh: 1: pnpm: not found
Error: Command failed: pnpm info caniuse-lite --json
```

`update-browserslist-db` detects the `pnpm-lock.yaml` in the repo and shells out to `pnpm info caniuse-lite --json` to find the latest `caniuse-lite` version (and to patch the lockfile). The workflow never installed pnpm, so the command exits 127 and the job fails before it can open a PR.

## Fix

Add a `pnpm/action-setup@v6` step (and enable `cache: pnpm` on `setup-node`) before running the tool, mirroring how every other workflow in the repo sets up pnpm. No `pnpm install` is needed since the tool only reads/patches the lockfile.