### PR TITLE
fix(build): exclude Safari/iOS < 14.1 from browserslist targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,9 @@
     "node >= 22.12.0",
     "> 0.27%",
     "not dead",
-    "not op_mini all"
+    "not op_mini all",
+    "not ios_saf < 14.1",
+    "not safari < 14.1"
   ],
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Problem

The `build` step fails with:

```
ERROR: Transforming destructuring to the configured target environment
(… "ios11" …) is not supported yet
```

Two things stack up here:

- esbuild does not implement destructuring lowering at all (it is not a full down-leveler), so when a target can't run destructuring it errors rather than emit possibly-broken output.
- esbuild's compat table marks destructuring as unsupported for Safari/iOS older than 14.1, because of a WebKit destructuring miscompilation bug that was fixed in Safari 14.1. (Verified empirically: `--target=safari14` fails, `--target=safari14.1` passes.)

esbuild derives its targets from the `browserslist` query. iOS Safari 11.0-11.2 currently sits at ~0.31% global usage, just above the `> 0.27%` threshold, so it gets pulled into the resolved set as `ios11`. That's a sub-14.1 target, so every `const {…}` in the source becomes a hard error.

This is why the auto-generated browserslist update (#584) breaks the build: refreshing caniuse-lite nudged iOS 11 over the threshold. The threshold sits right on iOS 11's usage boundary, so the build is fragile to any caniuse data shift.

## Fix

Exclude Safari/iOS older than 14.1 (the first version esbuild treats as supporting destructuring) from the query:

```diff
   "browserslist": [
     "node >= 22.12.0",
     "> 0.27%",
     "not dead",
-    "not op_mini all"
+    "not op_mini all",
+    "not ios_saf < 14.1",
+    "not safari < 14.1"
   ],
```

This only drops browsers esbuild physically cannot compile to. The resolved minimum becomes `ios16.6`, and `pnpm run build` passes end-to-end (verified locally).