### PR TITLE
chore: add prettier devDependency for release changelog formatting

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,5 +5,5 @@
     "config": ["vitest.config.ts", "vitest.*.config.ts"]
   },
   "ignoreBinaries": ["scripts/report-size.sh"],
-  "ignoreDependencies": ["@sanity/semantic-release-preset"]
+  "ignoreDependencies": ["@sanity/semantic-release-preset", "prettier"]
 }

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "oxfmt": "^0.52.0",
     "oxlint": "^1.67.0",
     "playwright": "^1.60.0",
+    "prettier": "^3.8.4",
     "semantic-release": "^25.0.3",
     "typescript": "6.0.3",
     "vitest": "^4.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@6.0.3)
@@ -3690,8 +3693,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -5821,7 +5824,7 @@ snapshots:
       lightningcss: 1.32.0
       mkdirp: 3.0.1
       outdent: 0.8.0
-      prettier: 3.8.3
+      prettier: 3.8.4
       pretty-bytes: 7.1.0
       prompts: 2.4.2
       rimraf: 6.1.3
@@ -8108,7 +8111,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@3.8.3: {}
+  prettier@3.8.4: {}
 
   pretty-bytes@7.1.0: {}
 


### PR DESCRIPTION
## Problem

The v9 release run failed in the semantic-release `prepare` step ([failed run](https://github.com/sanity-io/get-it/actions/runs/27235614827/job/80427157055)):

```
[semantic-release] [@semantic-release/exec] › ℹ  Call script npx -y prettier --write CHANGELOG.md
sh: 1: prettier: not found
```

`@sanity/semantic-release-preset` formats the changelog with `npx -y prettier --write CHANGELOG.md`. Since this repo switched from prettier to oxfmt, there is no local prettier install, and the `npx -y` cold-cache auto-install consistently fails on the CI runner (a re-run failed identically).

## Fix

- Add `prettier` as a devDependency so `npx` resolves the local binary instead of attempting a network install during the release
- Add `prettier` to knip's `ignoreDependencies` since it is only referenced by the release preset's exec command

Note: it may be worth fixing this upstream in `@sanity/semantic-release-preset` too (it assumes prettier is installable or present), but this unblocks the v9 release now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)