### PR TITLE
ci: give changesets version PR a conventional-commit title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,60 +5,20 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.repository_owner_id }}-${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read # for checkout
 
 jobs:
   release:
-    # Inlined from sanity-io/.github changesets.yml so we can give the
-    # "Version Packages" PR a conventional-commit title and commit message,
-    # keeping it green against the validate-pr-title check.
-    if: github.repository_owner == 'sanity-io'
+    uses: sanity-io/.github/.github/workflows/changesets.yml@main
     permissions:
       contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ secrets.ECOSPARK_APP_ID }}
-          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          # Uses generated token to allow pushing commits back
-          token: ${{ steps.app-token.outputs.token }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
-      - name: Get app token user id
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Setup git user
-        run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
-        with:
-          cache: pnpm
-          node-version: lts/*
-        # temporary until setup-node action comes with npm version that contains oidc setup by default
-      - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
-      - run: pnpm install --frozen-lockfile
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
-        with:
-          publish: pnpm release
-          title: 'chore: version packages'
-          commit: 'chore: version packages'
-          setupGitUser: false
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
+    with:
+      # Conventional-commit title/commit so the Version Packages PR stays
+      # green against the validate-pr-title check.
+      versionPrTitle: 'chore: version packages'
+      versionCommitMessage: 'chore: version packages'
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,60 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.repository_owner_id }}-${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read # for checkout
 
 jobs:
   release:
-    uses: sanity-io/.github/.github/workflows/changesets.yml@main
+    # Inlined from sanity-io/.github changesets.yml so we can give the
+    # "Version Packages" PR a conventional-commit title and commit message,
+    # keeping it green against the validate-pr-title check.
+    if: github.repository_owner == 'sanity-io'
     permissions:
       contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+      - name: Get app token user id
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Setup git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: lts/*
+        # temporary until setup-node action comes with npm version that contains oidc setup by default
+      - name: Update npm to use trusted publishing (OIDC)
+        run: npm install -g npm@latest
+      - run: pnpm install --frozen-lockfile
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1.6.0
+        with:
+          publish: pnpm release
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+          setupGitUser: false
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}


### PR DESCRIPTION
## Problem

The changesets "Version Packages" PR fails the `validate-pr-title` check, because changesets titles both the PR and the version-bump commit literally `Version Packages` - not conventional-commit format.

## Fix

The shared `sanity-io/.github` changesets workflow now exposes `versionPrTitle` / `versionCommitMessage` inputs (sanity-io/.github#31, merged). So this PR keeps the thin shared-workflow call and just passes `chore: version packages` for both:

```yaml
jobs:
  release:
    uses: sanity-io/.github/.github/workflows/changesets.yml@main
    with:
      versionPrTitle: 'chore: version packages'
      versionCommitMessage: 'chore: version packages'
    secrets: inherit
```

(An earlier revision of this PR inlined the whole workflow to achieve this; that's no longer necessary now that the shared workflow is configurable.)

## Why this is safe

Changesets determines version bumps from the `.changeset/*.md` files, not from commit messages or PR titles - unlike semantic-release. The `title`/`commit` inputs are purely cosmetic labels, so renaming changes nothing functionally. It just makes the Version Packages PR pass conventional-commit validation, and keeps `main` history consistent (`chore: version packages` rather than a bare `Version Packages` commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)