### PR TITLE
fix: import condition for worker(d)

### DIFF
--- a/.changeset/pr-594.md
+++ b/.changeset/pr-594.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': patch
+---
+
+fix: import condition for worker(d)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium firefox webkit
       - run: pnpm run test:browser -- --coverage
+      - run: pnpm run build
+      - run: pnpm run test:smoke:browser
 
   test-bun:
     name: Test Bun
@@ -95,6 +97,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: oven-sh/setup-bun@v2
       - run: pnpm run test:bun
+      - run: pnpm run build
+      - run: pnpm run test:smoke:bun
 
   test-deno:
     name: Test Deno
@@ -126,6 +130,8 @@ jobs:
           node-version: lts/*
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:happy-dom
+      - run: pnpm run build
+      - run: pnpm run test:smoke:happy-dom
 
   test-react-server:
     name: Test React Server
@@ -140,6 +146,8 @@ jobs:
           node-version: lts/*
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:react-server
+      - run: pnpm run build
+      - run: pnpm run test:smoke:react-server
 
   test-vercel-edge:
     name: Test Vercel Edge Runtime
@@ -154,6 +162,8 @@ jobs:
           node-version: lts/*
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:vercel-edge -- --coverage
+      - run: pnpm run build
+      - run: pnpm run test:smoke:vercel-edge
 
   test-workerd:
     name: Test workerd (Cloudflare Workers)
@@ -168,3 +178,5 @@ jobs:
           node-version: lts/*
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:workerd
+      - run: pnpm run build
+      - run: pnpm run test:smoke:workerd

--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
         "source": "./src/_exports/index.ts",
         "import": "./dist/index.js"
       },
+      "workerd": {
+        "source": "./src/_exports/index.ts",
+        "import": "./dist/index.js"
+      },
+      "worker": {
+        "source": "./src/_exports/index.ts",
+        "import": "./dist/index.js"
+      },
       "node": {
         "source": "./src/_exports/index.node.ts",
         "import": "./dist/index.node.js"
@@ -81,6 +89,12 @@
           "import": "./dist/index.js"
         },
         "deno": {
+          "import": "./dist/index.js"
+        },
+        "workerd": {
+          "import": "./dist/index.js"
+        },
+        "worker": {
           "import": "./dist/index.js"
         },
         "node": {
@@ -126,12 +140,19 @@
     "release": "changeset publish",
     "report-size": "scripts/report-size.sh",
     "test": "vitest run",
-    "test:all": "pnpm run test && pnpm run test:happy-dom && pnpm run test:bun && pnpm run test:deno && pnpm run test:vercel-edge && pnpm run test:react-server && pnpm run test:workerd",
+    "test:all": "pnpm run test && pnpm run test:happy-dom && pnpm run test:bun && pnpm run test:deno && pnpm run test:vercel-edge && pnpm run test:react-server && pnpm run test:workerd && pnpm run test:smoke",
     "test:browser": "pnpm test --config ./vitest.browser.config.ts",
     "test:bun": "bun run vitest run",
     "test:deno": "pnpm run build && deno test --no-lock test/deno/smoke.ts",
     "test:happy-dom": "pnpm test --config ./vitest.happy-dom.config.ts --dom",
     "test:react-server": "pnpm test --config ./vitest.react-server.config.ts",
+    "test:smoke": "pnpm run build && pnpm run test:smoke:workerd && pnpm run test:smoke:vercel-edge && pnpm run test:smoke:react-server && pnpm run test:smoke:happy-dom && pnpm run test:smoke:browser && pnpm run test:smoke:bun",
+    "test:smoke:browser": "pnpm test --config ./vitest.browser.smoke.config.ts",
+    "test:smoke:bun": "bun run vitest run --config ./vitest.bun.smoke.config.ts",
+    "test:smoke:happy-dom": "pnpm test --config ./vitest.happy-dom.smoke.config.ts",
+    "test:smoke:react-server": "pnpm test --config ./vitest.react-server.smoke.config.ts",
+    "test:smoke:vercel-edge": "pnpm test --config ./vitest.vercel-edge.smoke.config.ts",
+    "test:smoke:workerd": "pnpm test --config ./vitest.workerd.smoke.config.ts",
     "test:vercel-edge": "pnpm test --config ./vitest.vercel-edge.config.ts",
     "test:workerd": "pnpm test --config ./vitest.workerd.config.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.check.json && tsc --noEmit -p tsconfig.check-node.json"

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, test} from 'vitest'
+
+import pkg from '../package.json'
+
+/**
+ * Faithful packaging-resolution guard.
+ *
+ * The runtime test pools cannot catch entry-resolution bugs: `@cloudflare/vitest-pool-workers`
+ * explicitly *excludes* the `node` condition, so a workerd runtime test always resolves the
+ * fetch entry even though real wrangler with `nodejs_compat` enabled *includes* `node` and would
+ * resolve the Node entry (pulling in undici).
+ *
+ * This test resolves the published `exports` map directly against the exact condition set each
+ * target runtime uses - including the `node`-inclusive wrangler case - and asserts which entry
+ * wins. It reads `package.json` only; it never imports built code, so it runs in the regular
+ * suite without a build step.
+ */
+
+type ExportsNode = string | {[condition: string]: ExportsNode}
+
+function isConditions(node: ExportsNode): node is {[condition: string]: ExportsNode} {
+  return typeof node !== 'string'
+}
+
+/**
+ * Resolve an `exports` subtree against an explicit, exclusive set of active conditions.
+ * Conditions are matched in key order, first match wins - exactly how Node and bundlers
+ * resolve conditional exports. Unlike Node's own resolver, this does NOT implicitly add the
+ * `node` condition, so we can model non-Node runtimes faithfully.
+ */
+function resolveExports(node: ExportsNode, conditions: Set<string>): string | null {
+  if (!isConditions(node)) return node
+  for (const key of Object.keys(node)) {
+    if (key === 'default' || conditions.has(key)) {
+      const resolved = resolveExports(node[key], conditions)
+      if (resolved !== null) return resolved
+    }
+  }
+  return null
+}
+
+const exportsMap: ExportsNode = pkg.exports
+
+function resolve(subpath: string, conditions: string[]): string | null {
+  const entry = isConditions(exportsMap) ? exportsMap[subpath] : null
+  if (entry === undefined || entry === null) return null
+  // The `source` condition points at TypeScript and is only used by bundlers consuming
+  // from source; published runtime resolution must never select it.
+  return resolveExports(entry, new Set(conditions))
+}
+
+const FETCH_ENTRY = './dist/index.js'
+const NODE_ENTRY = './dist/index.node.js'
+
+describe('package exports resolution', () => {
+  // The runtimes that must NOT pull in the undici-backed Node entry. Each array is the
+  // exclusive set of conditions that runtime's resolver activates in production.
+  const fetchRuntimes: Record<string, string[]> = {
+    'wrangler + nodejs_compat': ['workerd', 'worker', 'browser', 'module', 'import', 'node'],
+    'wrangler (no nodejs_compat)': ['workerd', 'worker', 'browser', 'module', 'import'],
+    'vitest-pool-workers': ['workerd', 'worker', 'module', 'browser', 'import'],
+    'vercel edge-light': ['edge-light', 'worker', 'browser', 'module', 'import'],
+    'react-server (RSC)': ['react-server', 'browser', 'module', 'import'],
+    'deno': ['deno', 'import'],
+    'browser': ['browser', 'module', 'import'],
+  }
+
+  for (const [name, conditions] of Object.entries(fetchRuntimes)) {
+    test(`"." resolves to the fetch entry on ${name}`, () => {
+      expect(resolve('.', conditions)).toBe(FETCH_ENTRY)
+    })
+  }
+
+  // The runtimes that intentionally use the undici-backed Node entry.
+  const nodeRuntimes: Record<string, string[]> = {
+    node: ['node', 'import'],
+    bun: ['bun', 'import', 'node'],
+  }
+
+  for (const [name, conditions] of Object.entries(nodeRuntimes)) {
+    test(`"." resolves to the Node entry on ${name}`, () => {
+      expect(resolve('.', conditions)).toBe(NODE_ENTRY)
+    })
+  }
+
+  test('the "node" condition is ordered before the fetch fallback', () => {
+    // Regression guard for the original bug: a worker-like runtime that also activates the
+    // `node` condition (wrangler + nodejs_compat) must still land on the fetch entry, which is
+    // only true while a `workerd`/`worker` condition precedes `node` in the exports map.
+    const dot = isConditions(exportsMap) ? exportsMap['.'] : null
+    if (dot === null || !isConditions(dot)) throw new Error('exports["."] must be a conditions map')
+    const keys = Object.keys(dot)
+    const workerIndex = Math.min(
+      keys.indexOf('workerd') === -1 ? Infinity : keys.indexOf('workerd'),
+      keys.indexOf('worker') === -1 ? Infinity : keys.indexOf('worker'),
+    )
+    expect(workerIndex).toBeLessThan(keys.indexOf('node'))
+  })
+})

--- a/test/smoke/smoke.test.ts
+++ b/test/smoke/smoke.test.ts
@@ -1,0 +1,28 @@
+import {createRequester} from 'get-it'
+import {retry} from 'get-it/middleware'
+import {expect, test} from 'vitest'
+
+/**
+ * Built-asset smoke test, run against the published `dist` (no source alias) in
+ * each target runtime. Its job is to prove that the entry the runtime's resolver
+ * actually selects from the package.json `exports` map loads, initializes, and
+ * runs a request through the middleware pipeline.
+ *
+ * A `fetch` is injected so the test is deterministic and free of network or
+ * `data:`-URL support differences across runtimes - the resolution and module
+ * initialization is what we are exercising here, not the runtime's own fetch.
+ */
+test('the built get-it package resolves and runs a request', async () => {
+  const request = createRequester({
+    timeout: false,
+    fetch: () => Promise.resolve(new Response('hello from the built package', {status: 200})),
+  })
+
+  const response = await request({url: 'https://example.com/', as: 'text'})
+
+  expect(response.body).toBe('hello from the built package')
+})
+
+test('the built get-it/middleware subpath resolves', () => {
+  expect(typeof retry).toBe('function')
+})

--- a/vitest.browser.smoke.config.ts
+++ b/vitest.browser.smoke.config.ts
@@ -1,15 +1,14 @@
 import {playwright} from '@vitest/browser-playwright'
 import {defineConfig} from 'vitest/config'
 
-import {nonNodeExclude, sharedConfig} from './vitest.config'
+import {builtPackageAlias, smokeConfig} from './vitest.config'
 
-const {globalSetup, ...browserSharedConfig} = sharedConfig
-
+// Built-asset smoke test in real browsers, pinned to the fetch entry browsers resolve to (see
+// test/exports.test.ts). Verifies the built fetch entry loads and runs in Chromium/Firefox/WebKit.
 export default defineConfig({
   test: {
-    ...browserSharedConfig,
-    exclude: nonNodeExclude,
-    globalSetup,
+    ...smokeConfig,
+    alias: builtPackageAlias('./dist/index.js'),
     browser: {
       enabled: true,
       provider: playwright(),

--- a/vitest.bun.smoke.config.ts
+++ b/vitest.bun.smoke.config.ts
@@ -1,0 +1,13 @@
+import {defineConfig} from 'vitest/config'
+
+import {builtPackageAlias, smokeConfig} from './vitest.config'
+
+// Built-asset smoke test under the Bun runtime (run via `bun run vitest`), pinned to the
+// undici-backed Node entry that the `bun` condition resolves to (see test/exports.test.ts) -
+// the entry Bun consumers actually load. Verifies it loads and runs on Bun.
+export default defineConfig({
+  test: {
+    ...smokeConfig,
+    alias: builtPackageAlias('./dist/index.node.js'),
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,15 @@
 import {configDefaults, defineConfig, type ViteUserConfig} from 'vitest/config'
 
+// The built-asset smoke tests (test/smoke) resolve `get-it` through the real package.json
+// `exports` map against `dist`, so they must NOT run under the source-alias suites below.
+// They are run only by the dedicated `vitest.*.smoke.config.ts` configs.
+export const baseExclude = [...configDefaults.exclude, 'test/smoke/**']
+
+// Env suites that run against the source (browser/edge/worker/RSC) skip the Node-only tests.
+export const nonNodeExclude = [...baseExclude, 'test/*.node.test.ts']
+
 export const sharedConfig = {
-  exclude: configDefaults.exclude,
+  exclude: baseExclude,
   globalSetup: [
     './test/helpers/globalSetup.http.ts',
     './test/helpers/globalSetup.https.ts',
@@ -17,6 +25,29 @@ export const sharedConfig = {
     'get-it': new URL('./src/_exports', import.meta.url).pathname,
   },
 } satisfies ViteUserConfig['test']
+
+// Base for built-asset smoke configs. No `globalSetup` (smoke tests inject their own fetch and
+// never touch the test servers).
+export const smokeConfig = {
+  include: ['test/smoke/**/*.test.ts'],
+  reporters: process.env.GITHUB_ACTIONS ? ['default', 'github-actions'] : 'default',
+} satisfies ViteUserConfig['test']
+
+/**
+ * Aliases the `get-it` specifiers to the built `dist` entry a given runtime resolves to.
+ *
+ * Vite's resolver runs in Node, which always injects the `node` export condition, so non-pool
+ * smoke environments (edge-runtime, happy-dom, RSC, Bun) cannot resolve the runtime's real entry
+ * by conditions alone. We pin the entry explicitly instead; `test/exports.test.ts` is the
+ * faithful guard for *which* entry each runtime's condition set actually selects. The workerd
+ * smoke config does not use this - the cloudflare pool excludes `node` and resolves faithfully.
+ */
+export function builtPackageAlias(main: './dist/index.js' | './dist/index.node.js') {
+  return {
+    'get-it/middleware': new URL('./dist/middleware.js', import.meta.url).pathname,
+    'get-it': new URL(main, import.meta.url).pathname,
+  }
+}
 
 export default defineConfig({
   test: sharedConfig,

--- a/vitest.happy-dom.config.ts
+++ b/vitest.happy-dom.config.ts
@@ -1,11 +1,11 @@
-import {configDefaults, defineConfig} from 'vitest/config'
+import {defineConfig} from 'vitest/config'
 
-import {sharedConfig} from './vitest.config'
+import {nonNodeExclude, sharedConfig} from './vitest.config'
 
 export default defineConfig({
   test: {
     ...sharedConfig,
-    exclude: [...configDefaults.exclude, 'test/*.node.test.ts'],
+    exclude: nonNodeExclude,
     environment: 'happy-dom',
     setupFiles: ['./test/helpers/suppress-noise.ts'],
   },

--- a/vitest.happy-dom.smoke.config.ts
+++ b/vitest.happy-dom.smoke.config.ts
@@ -1,0 +1,14 @@
+import {defineConfig} from 'vitest/config'
+
+import {builtPackageAlias, smokeConfig} from './vitest.config'
+
+// Built-asset smoke test in a browser-like (happy-dom) environment, pinned to the fetch entry
+// browsers resolve to (see test/exports.test.ts).
+export default defineConfig({
+  test: {
+    ...smokeConfig,
+    environment: 'happy-dom',
+    setupFiles: ['./test/helpers/suppress-noise.ts'],
+    alias: builtPackageAlias('./dist/index.js'),
+  },
+})

--- a/vitest.react-server.config.ts
+++ b/vitest.react-server.config.ts
@@ -1,11 +1,11 @@
-import {configDefaults, defineConfig} from 'vitest/config'
+import {defineConfig} from 'vitest/config'
 
-import {sharedConfig} from './vitest.config'
+import {nonNodeExclude, sharedConfig} from './vitest.config'
 
 export default defineConfig({
   test: {
     ...sharedConfig,
-    exclude: [...configDefaults.exclude, 'test/*.node.test.ts'],
+    exclude: nonNodeExclude,
   },
   resolve: {
     conditions: ['react-server', 'node'],

--- a/vitest.react-server.smoke.config.ts
+++ b/vitest.react-server.smoke.config.ts
@@ -1,0 +1,15 @@
+import {defineConfig} from 'vitest/config'
+
+import {builtPackageAlias, smokeConfig} from './vitest.config'
+
+// Built-asset smoke test for React Server Components, pinned to the fetch entry that the
+// `react-server` condition resolves to (see test/exports.test.ts).
+export default defineConfig({
+  test: {
+    ...smokeConfig,
+    alias: builtPackageAlias('./dist/index.js'),
+  },
+  resolve: {
+    conditions: ['react-server', 'browser', 'module', 'import'],
+  },
+})

--- a/vitest.vercel-edge.config.ts
+++ b/vitest.vercel-edge.config.ts
@@ -1,11 +1,11 @@
-import {configDefaults, defineConfig} from 'vitest/config'
+import {defineConfig} from 'vitest/config'
 
-import {sharedConfig} from './vitest.config'
+import {nonNodeExclude, sharedConfig} from './vitest.config'
 
 export default defineConfig({
   test: {
     ...sharedConfig,
-    exclude: [...configDefaults.exclude, 'test/*.node.test.ts'],
+    exclude: nonNodeExclude,
     environment: 'edge-runtime',
   },
 })

--- a/vitest.vercel-edge.smoke.config.ts
+++ b/vitest.vercel-edge.smoke.config.ts
@@ -1,0 +1,14 @@
+import {defineConfig} from 'vitest/config'
+
+import {builtPackageAlias, smokeConfig} from './vitest.config'
+
+// Built-asset smoke test on the Vercel Edge runtime, pinned to the fetch entry that the
+// edge-light condition set resolves to (see test/exports.test.ts). Verifies the built fetch
+// entry loads and runs under edge-runtime.
+export default defineConfig({
+  test: {
+    ...smokeConfig,
+    environment: 'edge-runtime',
+    alias: builtPackageAlias('./dist/index.js'),
+  },
+})

--- a/vitest.workerd.config.ts
+++ b/vitest.workerd.config.ts
@@ -1,19 +1,21 @@
 import {cloudflareTest} from '@cloudflare/vitest-pool-workers'
-import {configDefaults, defineConfig} from 'vitest/config'
+import {defineConfig} from 'vitest/config'
 
-import {sharedConfig} from './vitest.config'
+import {nonNodeExclude, sharedConfig} from './vitest.config'
 
 export default defineConfig({
   plugins: [
     cloudflareTest({
       miniflare: {
         compatibilityDate: '2026-06-01',
-        compatibilityFlags: ['nodejs_compat'],
+        // No `nodejs_compat`: get-it must work on bare workerd. Enabling it would
+        // let the resolver match the `node` export condition and pull in undici.
+        compatibilityFlags: [],
       },
     }),
   ],
   test: {
     ...sharedConfig,
-    exclude: [...configDefaults.exclude, 'test/*.node.test.ts'],
+    exclude: nonNodeExclude,
   },
 })

--- a/vitest.workerd.smoke.config.ts
+++ b/vitest.workerd.smoke.config.ts
@@ -1,0 +1,20 @@
+import {cloudflareTest} from '@cloudflare/vitest-pool-workers'
+import {defineConfig} from 'vitest/config'
+
+import {smokeConfig} from './vitest.config'
+
+// Built-asset smoke test on workerd. The cloudflare pool resolves `get-it` through the real
+// `exports` map (no source alias) and, like real wrangler, excludes the `node` condition - so
+// this exercises the fetch entry on bare workerd. `compatibilityDate` is required (workerd will
+// not start without one); `nodejs_compat` is intentionally omitted.
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      miniflare: {
+        compatibilityDate: '2026-06-01',
+        compatibilityFlags: [],
+      },
+    }),
+  ],
+  test: smokeConfig,
+})


### PR DESCRIPTION
### Description

Importing v9 on cloudflare workers currently results in the node-variant, which tries to use undici. This wasn't covered by our workerd tests because it uses source imports instead of the main entry point (`get-it`) with compiled sources.

This PR:
- Adds explicit `worker` + `workerd` entries before the node entry to ensure we use the correct variant
- Adds smoke tests to more faithfully import from compiled sources
