### PR TITLE
feat(mock): allow responding with errors

### DIFF
--- a/.changeset/pr-598.md
+++ b/.changeset/pr-598.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat(mock): allow responding with errors

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -51,6 +51,16 @@ export interface RecordedRequest {
 export interface MockHandler {
   respond(def: MockResponseDef): MockHandler
   respondPersist(def: MockResponseDef): MockHandler
+  /**
+   * Reject the matched request with a transport-level error (mirrors how a real
+   * `fetch()` rejects on a failed connection), instead of resolving to a
+   * `Response`. Accepts an `Error` instance, or a factory invoked once per
+   * consumption so each rejection gets a fresh instance. The value is thrown
+   * unmodified, preserving `name`/`message`/`cause`.
+   */
+  respondWithError(error: Error | (() => Error)): MockHandler
+  /** Like {@link respondWithError}, but rejects on every matching request. */
+  respondWithErrorPersist(error: Error | (() => Error)): MockHandler
 }
 
 /**
@@ -90,11 +100,9 @@ export interface MockFetch {
 // Internal types
 // ---------------------------------------------------------------------------
 
-interface ResponseEntry {
-  def: MockResponseDef
-  persistent: boolean
-  consumed: boolean
-}
+type ResponseEntry =
+  | {kind: 'response'; def: MockResponseDef; persistent: boolean; consumed: boolean}
+  | {kind: 'error'; error: Error | (() => Error); persistent: boolean; consumed: boolean}
 
 interface InternalHandler {
   method: string | null // null = any method
@@ -135,6 +143,16 @@ function tryParseJson(value: string): {parsed: unknown} | undefined {
   } catch {
     return undefined
   }
+}
+
+/**
+ * Resolve an error entry to the error to throw. A factory function is invoked
+ * once per consumption so each rejection gets a fresh instance; the resulting
+ * value is thrown unmodified.
+ * @internal
+ */
+function resolveError(error: Error | (() => Error)): Error {
+  return typeof error === 'function' ? error() : error
 }
 
 /**
@@ -521,6 +539,10 @@ export function createMockFetch(): MockFetch {
         responseEntry.consumed = true
       }
 
+      if (responseEntry.kind === 'error') {
+        throw resolveError(responseEntry.error)
+      }
+
       return buildFetchResponse(responseEntry.def, input)
     }
 
@@ -586,11 +608,19 @@ export function createMockFetch(): MockFetch {
 
     const mockHandler: MockHandler = {
       respond(def: MockResponseDef): MockHandler {
-        handler.responses.push({def, persistent: false, consumed: false})
+        handler.responses.push({kind: 'response', def, persistent: false, consumed: false})
         return mockHandler
       },
       respondPersist(def: MockResponseDef): MockHandler {
-        handler.responses.push({def, persistent: true, consumed: false})
+        handler.responses.push({kind: 'response', def, persistent: true, consumed: false})
+        return mockHandler
+      },
+      respondWithError(error: Error | (() => Error)): MockHandler {
+        handler.responses.push({kind: 'error', error, persistent: false, consumed: false})
+        return mockHandler
+      },
+      respondWithErrorPersist(error: Error | (() => Error)): MockHandler {
+        handler.responses.push({kind: 'error', error, persistent: true, consumed: false})
         return mockHandler
       },
     }

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -794,4 +794,85 @@ describe('createMockFetch', () => {
       }
     })
   })
+
+  describe('respondWithError', () => {
+    it('rejects with the provided error instance, preserving name/message/cause', async () => {
+      const mock = createMockFetch()
+      const cause = {code: 'ECONNRESET'}
+      const boom = new TypeError('fetch failed', {cause})
+      mock.on('GET', '/x').respondWithError(boom)
+
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/x')
+      } catch (err: unknown) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(TypeError)
+      expect(error).toBe(boom)
+      if (!(error instanceof Error)) throw new Error('expected an Error')
+      expect(error.name).toBe('TypeError')
+      expect(error.message).toBe('fetch failed')
+      expect(error.cause).toBe(cause)
+    })
+
+    it('invokes a factory once per consumption, yielding fresh instances', async () => {
+      const mock = createMockFetch()
+      let calls = 0
+      mock.onAny('/x').respondWithErrorPersist(() => new TypeError(`attempt ${++calls}`))
+
+      let first: unknown
+      let second: unknown
+      try {
+        await mock.fetch('https://h/x')
+      } catch (err: unknown) {
+        first = err
+      }
+      try {
+        await mock.fetch('https://h/x')
+      } catch (err: unknown) {
+        second = err
+      }
+
+      if (!(first instanceof Error) || !(second instanceof Error)) {
+        throw new Error('expected two Errors')
+      }
+      expect(first).not.toBe(second)
+      expect(first.message).toBe('attempt 1')
+      expect(second.message).toBe('attempt 2')
+    })
+
+    it('records the request even when it rejects', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/x').respondWithError(new TypeError('boom'))
+
+      let threw = false
+      try {
+        await mock.fetch('https://h/x', {method: 'POST'})
+      } catch {
+        threw = true
+      }
+
+      expect(threw).toBe(true)
+      const requests = mock.getRequests()
+      expect(requests).toHaveLength(1)
+      expect(requests[0].method).toBe('POST')
+    })
+
+    it('respondWithErrorPersist rejects on every matching request', async () => {
+      const mock = createMockFetch()
+      mock.onAny('/x').respondWithErrorPersist(new TypeError('down'))
+
+      for (let i = 0; i < 3; i++) {
+        let error: unknown
+        try {
+          await mock.fetch('https://h/x')
+        } catch (err: unknown) {
+          error = err
+        }
+        expect(error).toBeInstanceOf(TypeError)
+      }
+    })
+  })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -874,5 +874,69 @@ describe('createMockFetch', () => {
         expect(error).toBeInstanceOf(TypeError)
       }
     })
+
+    it('assertAllConsumed throws while an error response is unconsumed', () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/x').respondWithError(new TypeError('boom'))
+      expect(() => mock.assertAllConsumed()).toThrow(/unconsumed/)
+    })
+
+    it('assertAllConsumed passes once the error response is consumed', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/x').respondWithError(new TypeError('boom'))
+      try {
+        await mock.fetch('https://h/x')
+      } catch {
+        // expected rejection
+      }
+      expect(() => mock.assertAllConsumed()).not.toThrow()
+    })
+
+    it('respondWithErrorPersist leaves nothing unconsumed', async () => {
+      const mock = createMockFetch()
+      mock.onAny('/x').respondWithErrorPersist(new TypeError('down'))
+      try {
+        await mock.fetch('https://h/x')
+      } catch {
+        // expected rejection
+      }
+      expect(() => mock.assertAllConsumed()).not.toThrow()
+    })
+
+    it('queues an error then a success in order (retry-recovery shape)', async () => {
+      const mock = createMockFetch()
+      mock
+        .on('GET', '/x')
+        .respondWithError(new TypeError('transient'))
+        .respond({status: 200, body: {ok: true}})
+
+      let error: unknown
+      try {
+        await mock.fetch('https://h/x')
+      } catch (err: unknown) {
+        error = err
+      }
+      expect(error).toBeInstanceOf(TypeError)
+
+      const res = await mock.fetch('https://h/x')
+      expect(res.status).toBe(200)
+      mock.assertAllConsumed()
+    })
+
+    it('rejects through scope()', async () => {
+      const mock = createMockFetch()
+      mock
+        .scope('https://api.example.com')
+        .on('GET', '/x')
+        .respondWithError(new TypeError('scoped boom'))
+
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/x')
+      } catch (err: unknown) {
+        error = err
+      }
+      expect(error).toBeInstanceOf(TypeError)
+    })
   })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1,4 +1,5 @@
 import {createRequester} from 'get-it'
+import {retry} from 'get-it/middleware'
 import {describe, expect, it} from 'vitest'
 
 import {createMockFetch} from '../../src/mock/createMockFetch'
@@ -937,6 +938,54 @@ describe('createMockFetch', () => {
         error = err
       }
       expect(error).toBeInstanceOf(TypeError)
+    })
+  })
+
+  describe('respondWithError + retry middleware', () => {
+    it('retries a mocked network error, then succeeds', async () => {
+      const mock = createMockFetch()
+      mock
+        .on('GET', '/flaky')
+        .respondWithError(new TypeError('fetch failed', {cause: {code: 'ECONNRESET'}}))
+        .respond({status: 200, body: {ok: true}})
+
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: mock.fetch,
+        httpErrors: false,
+        middleware: [retry({retryDelay: () => 0})],
+      })
+
+      const res = await request({url: '/flaky', as: 'json'})
+
+      expect(res.body).toEqual({ok: true})
+      expect(mock.getRequests()).toHaveLength(2)
+      mock.assertAllConsumed()
+    })
+
+    it('exhausts retries and rejects with the network error', async () => {
+      const mock = createMockFetch()
+      mock
+        .onAny('/permafail')
+        .respondWithErrorPersist(new TypeError('fetch failed', {cause: {code: 'ECONNRESET'}}))
+
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: mock.fetch,
+        httpErrors: false,
+        middleware: [retry({maxRetries: 2, retryDelay: () => 0})],
+      })
+
+      let error: unknown
+      try {
+        await request({url: '/permafail'})
+      } catch (err: unknown) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(TypeError)
+      // initial attempt + 2 retries
+      expect(mock.getRequests()).toHaveLength(3)
     })
   })
 })


### PR DESCRIPTION
`get-it/mock` can only produce *HTTP* responses - every registered handler resolves to a `Response` with a status code. There is no way to make a mocked request **reject** with a transport-level error (the kind of `TypeError` a real `fetch()` throws when the connection fails, DNS doesn't resolve, the socket is reset, etc.).

This matters because a lot of client logic branches specifically on the *network error vs. HTTP error* distinction - most notably retry middleware, which typically retries transport failures but not arbitrary 4xx responses. Today there is no way to exercise those paths with `get-it/mock`.
