### PR TITLE
chore: ignore formatting of changeset markdown files

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,5 +6,6 @@
   "semi": false,
   "singleQuote": true,
   "quoteProps": "consistent",
-  "bracketSpacing": false
+  "bracketSpacing": false,
+  "ignorePatterns": [".changeset/*.md"]
 }


### PR DESCRIPTION
### Description

The generated changesets triggers an oxfmt PR to format them, which is annoying since they're temporary. oxfmt also changes the formatting to something that _might_ not be compatible with changesets, so instead of having it format the changeset file according to oxfmt rules, I feel it is better to ignore them from formatting.
