### PR TITLE
feat(mock): delay response

### DIFF
--- a/.changeset/pr-602.md
+++ b/.changeset/pr-602.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat(mock): delay response

--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ mock
 
 Use `.respondPersist()` for handlers that should match indefinitely.
 
+### Delayed responses
+
+Use the `delay` option to simulate server response time (in milliseconds):
+
+```ts
+mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 100})
+```
+
+The request is treated as sent immediately; the response resolves after `delay` ms. If the request is aborted before the delay elapses - via an `AbortController` signal or a get-it `timeout` - it rejects with the signal's reason and the pending timer is cleared.
+
 ### Scoped mocks
 
 When your code talks to multiple hosts, use `mock.scope()` to assert the right requests go to the right place:

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -29,6 +29,12 @@ export interface MockResponseDef {
   statusText?: string
   body?: unknown
   headers?: Record<string, string>
+  /**
+   * Delay in milliseconds before the response resolves, simulating server
+   * response time. The request is treated as sent immediately; this is how
+   * long the "server" takes to respond. Values <= 0 resolve immediately.
+   */
+  delay?: number
 }
 
 /**
@@ -543,7 +549,12 @@ export function createMockFetch(): MockFetch {
         throw resolveError(responseEntry.error)
       }
 
-      return buildFetchResponse(responseEntry.def, input)
+      const {def} = responseEntry
+      if (def.delay !== undefined && def.delay > 0) {
+        const ms = def.delay
+        await new Promise<void>((resolve) => setTimeout(resolve, ms))
+      }
+      return buildFetchResponse(def, input)
     }
 
     // No match found — build error

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -162,6 +162,30 @@ function resolveError(error: Error | (() => Error)): Error {
 }
 
 /**
+ * Wait `ms` milliseconds, rejecting with the signal's reason if it aborts
+ * first. Clears the timer on abort so it cannot resolve a request that should
+ * already have rejected.
+ * @internal
+ */
+function delayWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason)
+      return
+    }
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal?.reason)
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', onAbort, {once: true})
+  })
+}
+
+/**
  * Build a FetchResponse-compatible object from a MockResponseDef.
  * @internal
  */
@@ -551,8 +575,7 @@ export function createMockFetch(): MockFetch {
 
       const {def} = responseEntry
       if (def.delay !== undefined && def.delay > 0) {
-        const ms = def.delay
-        await new Promise<void>((resolve) => setTimeout(resolve, ms))
+        await delayWithAbort(def.delay, init?.signal)
       }
       return buildFetchResponse(def, input)
     }

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1015,5 +1015,70 @@ describe('createMockFetch', () => {
 
       expect(elapsed).toBeLessThan(40)
     })
+
+    it('rejects with the signal reason when aborted during the delay', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 1000})
+
+      const controller = new AbortController()
+      const promise = mock.fetch('https://api.example.com/slow', {
+        method: 'GET',
+        signal: controller.signal,
+      })
+      controller.abort()
+
+      let error: unknown
+      try {
+        await promise
+      } catch (err) {
+        error = err
+      }
+      expect(error).toBeInstanceOf(DOMException)
+      if (!(error instanceof DOMException)) throw new Error('expected a DOMException')
+      expect(error.name).toBe('AbortError')
+    })
+
+    it('propagates a custom abort reason', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 1000})
+
+      const reason = new Error('boom')
+      const controller = new AbortController()
+      const promise = mock.fetch('https://api.example.com/slow', {
+        method: 'GET',
+        signal: controller.signal,
+      })
+      controller.abort(reason)
+
+      let error: unknown
+      try {
+        await promise
+      } catch (err) {
+        error = err
+      }
+      expect(error).toBe(reason)
+    })
+
+    it('rejects immediately when the signal is already aborted', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 1000})
+
+      const reason = new Error('already gone')
+      const controller = new AbortController()
+      controller.abort(reason)
+
+      const start = Date.now()
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/slow', {
+          method: 'GET',
+          signal: controller.signal,
+        })
+      } catch (err) {
+        error = err
+      }
+      expect(Date.now() - start).toBeLessThan(40)
+      expect(error).toBe(reason)
+    })
   })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -988,4 +988,32 @@ describe('createMockFetch', () => {
       expect(mock.getRequests()).toHaveLength(3)
     })
   })
+
+  describe('delay', () => {
+    it('resolves the response after the configured delay', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 50})
+
+      const start = Date.now()
+      const res = await mock.fetch('https://api.example.com/slow', {method: 'GET'})
+      const elapsed = Date.now() - start
+
+      expect(elapsed).toBeGreaterThanOrEqual(45)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe(JSON.stringify({ok: true}))
+    })
+
+    it('resolves immediately when delay is 0 or omitted', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/zero').respond({status: 200, body: {a: 1}, delay: 0})
+      mock.on('GET', '/none').respond({status: 200, body: {b: 2}})
+
+      const start = Date.now()
+      await mock.fetch('https://api.example.com/zero', {method: 'GET'})
+      await mock.fetch('https://api.example.com/none', {method: 'GET'})
+      const elapsed = Date.now() - start
+
+      expect(elapsed).toBeLessThan(40)
+    })
+  })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1091,13 +1091,22 @@ describe('createMockFetch', () => {
         httpErrors: false,
       })
 
+      const start = Date.now()
       let error: unknown
       try {
         await request({url: '/slow', timeout: 50, as: 'json'})
       } catch (err) {
         error = err
       }
+      const elapsed = Date.now() - start
+
+      // Should reject well before the 1000ms delay completes
+      expect(elapsed).toBeLessThan(500)
+
+      // AbortSignal.timeout() produces a DOMException with name 'TimeoutError'
       expect(error).toBeInstanceOf(Error)
+      if (!(error instanceof Error)) throw error
+      expect(error.name).toBe('TimeoutError')
     })
   })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1080,5 +1080,24 @@ describe('createMockFetch', () => {
       expect(Date.now() - start).toBeLessThan(40)
       expect(error).toBe(reason)
     })
+
+    it('surfaces a timeout error when the get-it timeout is shorter than the delay', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/slow').respondPersist({status: 200, body: {ok: true}, delay: 1000})
+
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: mock.fetch,
+        httpErrors: false,
+      })
+
+      let error: unknown
+      try {
+        await request({url: '/slow', timeout: 50, as: 'json'})
+      } catch (err) {
+        error = err
+      }
+      expect(error).toBeInstanceOf(Error)
+    })
   })
 })


### PR DESCRIPTION
This adds a `delay` option on mocked responses, which simulates the _server_ being slow to respond. This leaves open the door for a `requestDelay` option which simulates a slow _outgoing_ response, but I don't see as much of a need for that right now. The response delay has real use cases in for instance the sanity client tests, however.
