### PR TITLE
feat(mock): request body matching for all body types

### DIFF
--- a/.changeset/mock-binary-body.md
+++ b/.changeset/mock-binary-body.md
@@ -1,0 +1,5 @@
+---
+'get-it': minor
+---
+
+mock: record and match binary (`Uint8Array` / `ArrayBuffer`) and `ReadableStream` request bodies as bytes, and add a `bodyBytes()` matcher

--- a/.changeset/mock-body-types.md
+++ b/.changeset/mock-body-types.md
@@ -1,0 +1,5 @@
+---
+'get-it': minor
+---
+
+mock: record and match the remaining request body types - `Blob`/`File`, `FormData`, and `URLSearchParams` - add a `headers` match option, and support array values in `queryContaining`

--- a/src/_exports/mock.ts
+++ b/src/_exports/mock.ts
@@ -13,6 +13,7 @@ export type {AsymmetricMatcher} from '../mock/matchers'
 export {
   anyValue,
   arrayContaining,
+  bodyBytes,
   objectContaining,
   queryContaining,
   stringMatching,

--- a/src/mock/body.ts
+++ b/src/mock/body.ts
@@ -74,8 +74,8 @@ function randomBoundary(): string {
 
 /**
  * The `Content-Type` the platform `fetch` would set for a given body, or null
- * when the body type has no default. Order matters: `File` extends `Blob`, and
- * `FormData`/`URLSearchParams` are not `Blob`s.
+ * when the body type has no default. `File` is handled by the `Blob` branch
+ * (it extends `Blob`); `FormData`/`URLSearchParams` are not `Blob`s.
  * @internal
  */
 export function contentTypeFor(rawBody: unknown): string | null {

--- a/src/mock/body.ts
+++ b/src/mock/body.ts
@@ -1,0 +1,100 @@
+/**
+ * A file/blob entry from a normalized `FormData` body.
+ * @internal
+ */
+export interface NormalizedFile {
+  name: string
+  type: string
+  size: number
+  bytes: Uint8Array
+}
+
+/** A normalized `FormData` field value. @internal */
+export type FormValue = string | NormalizedFile
+
+/**
+ * Read a `Blob` (or `File`) fully into a `Uint8Array`.
+ * @internal
+ */
+export async function blobToBytes(blob: Blob): Promise<Uint8Array> {
+  return new Uint8Array(await blob.arrayBuffer())
+}
+
+/**
+ * Normalize `URLSearchParams` to a plain record. A single value stays a string;
+ * duplicate keys collapse to an array (preserving multi-value params).
+ * @internal
+ */
+export function normalizeUrlSearchParams(params: URLSearchParams): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {}
+  for (const key of new Set(params.keys())) {
+    const all = params.getAll(key)
+    out[key] = all.length > 1 ? all : all[0]
+  }
+  return out
+}
+
+/**
+ * Normalize `FormData` to a plain record. String entries stay strings; `File`
+ * entries become `{name, type, size, bytes}`; a field appearing multiple times
+ * becomes an array in append order. The multipart boundary is never involved.
+ * @internal
+ */
+export async function normalizeFormData(
+  form: FormData,
+): Promise<Record<string, FormValue | FormValue[]>> {
+  const grouped = new Map<string, FormValue[]>()
+  for (const [key, value] of form.entries()) {
+    const normalized: FormValue =
+      typeof value === 'string'
+        ? value
+        : {name: value.name, type: value.type, size: value.size, bytes: await blobToBytes(value)}
+    const existing = grouped.get(key)
+    if (existing) {
+      existing.push(normalized)
+    } else {
+      grouped.set(key, [normalized])
+    }
+  }
+  const out: Record<string, FormValue | FormValue[]> = {}
+  for (const [key, values] of grouped) {
+    out[key] = values.length > 1 ? values : values[0]
+  }
+  return out
+}
+
+/**
+ * Generate a random multipart boundary. The value is arbitrary — assertions
+ * should match the `multipart/form-data` prefix, not the boundary.
+ * @internal
+ */
+function randomBoundary(): string {
+  return `----MockFetchFormBoundary${Math.random().toString(16).slice(2)}`
+}
+
+/**
+ * The `Content-Type` the platform `fetch` would set for a given body, or null
+ * when the body type has no default. Order matters: `File` extends `Blob`, and
+ * `FormData`/`URLSearchParams` are not `Blob`s.
+ * @internal
+ */
+export function contentTypeFor(rawBody: unknown): string | null {
+  if (rawBody instanceof URLSearchParams) return 'application/x-www-form-urlencoded;charset=UTF-8'
+  if (rawBody instanceof FormData) return `multipart/form-data; boundary=${randomBoundary()}`
+  if (rawBody instanceof Blob) return rawBody.type === '' ? null : rawBody.type
+  return null
+}
+
+/**
+ * Normalize a handler's expected body to the same canonical form the mock
+ * records for the actual request. Native body types are converted; any other
+ * value (plain object, asymmetric matcher, string, bytes) passes through
+ * unchanged.
+ * @internal
+ */
+export async function normalizeExpectedBody(value: unknown): Promise<unknown> {
+  if (value instanceof URLSearchParams) return normalizeUrlSearchParams(value)
+  if (value instanceof FormData) return normalizeFormData(value)
+  if (value instanceof Blob) return blobToBytes(value)
+  return value
+}

--- a/src/mock/bytes.ts
+++ b/src/mock/bytes.ts
@@ -1,0 +1,28 @@
+/**
+ * Check whether a value is a binary body the mock knows how to normalize to bytes.
+ * @internal
+ */
+export function isBinaryBody(value: unknown): value is Uint8Array | ArrayBuffer {
+  return value instanceof Uint8Array || value instanceof ArrayBuffer
+}
+
+/**
+ * View a binary value as a `Uint8Array`. A `Uint8Array` (including a `Buffer`)
+ * is returned as-is; an `ArrayBuffer` is wrapped. Does not copy.
+ * @internal
+ */
+export function toBytes(value: Uint8Array | ArrayBuffer): Uint8Array {
+  return value instanceof Uint8Array ? value : new Uint8Array(value)
+}
+
+/**
+ * Compare two byte arrays for exact equality (length then byte-by-byte).
+ * @internal
+ */
+export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -508,10 +508,15 @@ function buildDiffs(
 
   // Body diff
   if (handler.matchOptions.body !== undefined && !matchBody(handler.matchOptions.body, body)) {
-    if (isRecord(handler.matchOptions.body) || Array.isArray(handler.matchOptions.body)) {
-      diffs.push(...diffValues('body', handler.matchOptions.body, body))
+    const expectedBody = handler.matchOptions.body
+    const useStructuralDiff =
+      (isRecord(expectedBody) || Array.isArray(expectedBody)) &&
+      !isBinaryBody(expectedBody) &&
+      !isBinaryBody(body)
+    if (useStructuralDiff) {
+      diffs.push(...diffValues('body', expectedBody, body))
     } else {
-      diffs.push({path: 'body', expected: handler.matchOptions.body, actual: body})
+      diffs.push({path: 'body', expected: expectedBody, actual: body})
     }
   }
 

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -1,4 +1,5 @@
 import type {FetchFunction, FetchResponse} from '../types'
+import {blobToBytes, contentTypeFor, normalizeExpectedBody} from './body'
 import {bytesEqual, isBinaryBody, toBytes} from './bytes'
 import type {Diff} from './diff'
 import {diffValues} from './diff'
@@ -119,6 +120,7 @@ interface InternalHandler {
   patternQuery: Record<string, string> // query parsed from the url pattern
   matchOptions: MockMatchOptions
   responses: ResponseEntry[]
+  normalizedBody?: {value: unknown}
 }
 
 // ---------------------------------------------------------------------------
@@ -231,6 +233,14 @@ function matchBody(expected: unknown, actual: unknown): boolean {
     return actual instanceof Uint8Array && bytesEqual(toBytes(expected), actual)
   }
   return deepMatch(expected, actual)
+}
+
+/**
+ * The handler's expected body, normalized if it was a native body type.
+ * @internal
+ */
+function expectedBodyOf(handler: InternalHandler): unknown {
+  return handler.normalizedBody ? handler.normalizedBody.value : handler.matchOptions.body
 }
 
 /**
@@ -472,7 +482,7 @@ function scoreMatch(
   }
 
   // Body match
-  if (handler.matchOptions.body === undefined || matchBody(handler.matchOptions.body, body)) {
+  if (handler.matchOptions.body === undefined || matchBody(expectedBodyOf(handler), body)) {
     score += 1
   }
 
@@ -552,8 +562,8 @@ function buildDiffs(
   }
 
   // Body diff
-  if (handler.matchOptions.body !== undefined && !matchBody(handler.matchOptions.body, body)) {
-    const expectedBody = handler.matchOptions.body
+  if (handler.matchOptions.body !== undefined && !matchBody(expectedBodyOf(handler), body)) {
+    const expectedBody = expectedBodyOf(handler)
     const useStructuralDiff =
       (isRecord(expectedBody) || Array.isArray(expectedBody)) &&
       !isBinaryBody(expectedBody) &&
@@ -623,7 +633,6 @@ export function createMockFetch(): MockFetch {
     const normalizedHeaders = isHeaders(init?.headers)
       ? new Headers(init.headers)
       : new Headers(init?.headers ?? undefined)
-    const headerRecord = toHeaderRecord(normalizedHeaders)
 
     // Parse / normalize the request body for recording and matching.
     let body: unknown = undefined
@@ -646,10 +655,20 @@ export function createMockFetch(): MockFetch {
         body = new Uint8Array(toBytes(rawBody))
       } else if (rawBody instanceof ReadableStream) {
         body = await drainStream(rawBody)
+      } else if (rawBody instanceof Blob) {
+        // File extends Blob; a bare blob/file body sends only bytes on the wire.
+        body = await blobToBytes(rawBody)
       }
-      // Blob / FormData / URLSearchParams bodies are not yet normalized and
-      // remain unrecorded (body stays undefined).
     }
+
+    // Mirror platform fetch: set the default content-type for this body type
+    // when the caller did not set one, so it is recorded and matchable.
+    const synthesizedContentType = contentTypeFor(rawBody)
+    if (synthesizedContentType !== null && !normalizedHeaders.has('content-type')) {
+      normalizedHeaders.set('content-type', synthesizedContentType)
+    }
+
+    const headerRecord = toHeaderRecord(normalizedHeaders)
 
     // Record the request
     recordedRequests.push({
@@ -660,6 +679,13 @@ export function createMockFetch(): MockFetch {
       headers: normalizedHeaders,
       body,
     })
+
+    // Normalize native-type expected bodies once (async for Blob/FormData), cached per handler.
+    for (const handler of handlers) {
+      if (handler.matchOptions.body !== undefined && handler.normalizedBody === undefined) {
+        handler.normalizedBody = {value: await normalizeExpectedBody(handler.matchOptions.body)}
+      }
+    }
 
     // Find matching handler
     for (const handler of handlers) {
@@ -676,7 +702,7 @@ export function createMockFetch(): MockFetch {
       if (!queryMatches(handler, query)) continue
 
       // Check body
-      if (handler.matchOptions.body !== undefined && !matchBody(handler.matchOptions.body, body)) {
+      if (handler.matchOptions.body !== undefined && !matchBody(expectedBodyOf(handler), body)) {
         continue
       }
 

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -19,6 +19,7 @@ import {matchUrl, parseUrl} from './urlMatch'
 export interface MockMatchOptions {
   query?: Record<string, string | number | boolean> | AsymmetricMatcher
   body?: unknown
+  headers?: Record<string, string | AsymmetricMatcher> | AsymmetricMatcher
 }
 
 /**
@@ -138,6 +139,42 @@ function isHeaders(value: unknown): value is Headers {
  */
 function getContentType(headers: Headers): string | null {
   return headers.get('content-type')
+}
+
+/**
+ * Build a lowercased-key record of a request's headers for matching.
+ * `Headers.forEach` already yields lowercased names.
+ * @internal
+ */
+function toHeaderRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    record[key] = value
+  })
+  return record
+}
+
+/**
+ * Whether a handler constrains request headers.
+ * @internal
+ */
+function hasHeadersConstraint(handler: InternalHandler): boolean {
+  return handler.matchOptions.headers !== undefined
+}
+
+/**
+ * Match a handler's `headers` constraint against a request's headers.
+ * Containing semantics; keys are case-insensitive (compared lowercased).
+ * @internal
+ */
+function headersMatch(handler: InternalHandler, headerRecord: Record<string, string>): boolean {
+  const expected = handler.matchOptions.headers
+  if (expected === undefined) return true
+  if (isAsymmetricMatcher(expected)) return expected.asymmetricMatch(headerRecord)
+  return Object.keys(expected).every((key) => {
+    const lower = key.toLowerCase()
+    return lower in headerRecord && deepMatch(expected[key], headerRecord[lower])
+  })
 }
 
 /**
@@ -410,6 +447,7 @@ function scoreMatch(
   path: string,
   query: Record<string, string>,
   body: unknown,
+  headerRecord: Record<string, string>,
 ): number {
   let score = 0
 
@@ -435,6 +473,11 @@ function scoreMatch(
 
   // Body match
   if (handler.matchOptions.body === undefined || matchBody(handler.matchOptions.body, body)) {
+    score += 1
+  }
+
+  // Headers match
+  if (!hasHeadersConstraint(handler) || headersMatch(handler, headerRecord)) {
     score += 1
   }
 
@@ -477,6 +520,7 @@ function buildDiffs(
   path: string,
   query: Record<string, string>,
   body: unknown,
+  headerRecord: Record<string, string>,
 ): Diff[] {
   const diffs: Diff[] = []
 
@@ -518,6 +562,21 @@ function buildDiffs(
       diffs.push(...diffValues('body', expectedBody, body))
     } else {
       diffs.push({path: 'body', expected: expectedBody, actual: body})
+    }
+  }
+
+  // Headers diff
+  if (hasHeadersConstraint(handler) && !headersMatch(handler, headerRecord)) {
+    const expected = handler.matchOptions.headers
+    if (expected === undefined || isAsymmetricMatcher(expected)) {
+      diffs.push({path: 'headers', expected, actual: headerRecord})
+    } else {
+      for (const key of Object.keys(expected)) {
+        const lower = key.toLowerCase()
+        if (!(lower in headerRecord) || !deepMatch(expected[key], headerRecord[lower])) {
+          diffs.push({path: `headers.${key}`, expected: expected[key], actual: headerRecord[lower]})
+        }
+      }
     }
   }
 
@@ -564,6 +623,7 @@ export function createMockFetch(): MockFetch {
     const normalizedHeaders = isHeaders(init?.headers)
       ? new Headers(init.headers)
       : new Headers(init?.headers ?? undefined)
+    const headerRecord = toHeaderRecord(normalizedHeaders)
 
     // Parse / normalize the request body for recording and matching.
     let body: unknown = undefined
@@ -620,6 +680,9 @@ export function createMockFetch(): MockFetch {
         continue
       }
 
+      // Check headers
+      if (hasHeadersConstraint(handler) && !headersMatch(handler, headerRecord)) continue
+
       // Find first unconsumed response
       const responseEntry = findAvailableResponse(handler)
       if (responseEntry === undefined) continue
@@ -650,7 +713,7 @@ export function createMockFetch(): MockFetch {
     let closestHandler: InternalHandler | undefined
     let closestScore = -1
     for (const handler of handlers) {
-      const score = scoreMatch(handler, method, requestOrigin, path, query, body)
+      const score = scoreMatch(handler, method, requestOrigin, path, query, body, headerRecord)
       if (score > closestScore) {
         closestScore = score
         closestHandler = handler
@@ -661,7 +724,7 @@ export function createMockFetch(): MockFetch {
     let closestDescription: string | undefined
     if (closestHandler !== undefined) {
       closestDescription = describeHandler(closestHandler)
-      diffs = buildDiffs(closestHandler, method, requestOrigin, path, query, body)
+      diffs = buildDiffs(closestHandler, method, requestOrigin, path, query, body, headerRecord)
     }
 
     throw new MockFetchError(method, path, query, body, diffs, allMocks, closestDescription)

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -1,5 +1,11 @@
 import type {FetchFunction, FetchResponse} from '../types'
-import {blobToBytes, contentTypeFor, normalizeExpectedBody, normalizeUrlSearchParams} from './body'
+import {
+  blobToBytes,
+  contentTypeFor,
+  normalizeExpectedBody,
+  normalizeFormData,
+  normalizeUrlSearchParams,
+} from './body'
 import {bytesEqual, isBinaryBody, toBytes} from './bytes'
 import type {Diff} from './diff'
 import {diffValues} from './diff'
@@ -660,6 +666,8 @@ export function createMockFetch(): MockFetch {
         body = await blobToBytes(rawBody)
       } else if (rawBody instanceof URLSearchParams) {
         body = normalizeUrlSearchParams(rawBody)
+      } else if (rawBody instanceof FormData) {
+        body = await normalizeFormData(rawBody)
       }
     }
 

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -453,7 +453,8 @@ function queryMatches(handler: InternalHandler, query: Record<string, string>): 
 
 /**
  * Score how well a handler matches a request. Higher is better.
- * Returns 0-5 based on which dimensions match.
+ * Returns 0-6 based on which dimensions match (origin, method, URL, query,
+ * body, headers).
  * @internal
  */
 function scoreMatch(

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -1,4 +1,5 @@
 import type {FetchFunction, FetchResponse} from '../types'
+import {bytesEqual, isBinaryBody, toBytes} from './bytes'
 import type {Diff} from './diff'
 import {diffValues} from './diff'
 import type {MockDescription} from './errors'
@@ -149,6 +150,49 @@ function tryParseJson(value: string): {parsed: unknown} | undefined {
   } catch {
     return undefined
   }
+}
+
+/**
+ * Drain a readable stream fully into a single `Uint8Array`. Only the mock's
+ * async `fetch` can safely consume a request-body stream once.
+ * @internal
+ */
+async function drainStream(stream: ReadableStream): Promise<Uint8Array> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
+    const value: unknown = chunk.value
+    if (value instanceof Uint8Array) {
+      chunks.push(value)
+      total += value.byteLength
+    } else if (value instanceof ArrayBuffer) {
+      const bytes = new Uint8Array(value)
+      chunks.push(bytes)
+      total += bytes.byteLength
+    }
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
+}
+
+/**
+ * Match a request body against a handler's expected body. Raw binary
+ * (`Uint8Array` / `ArrayBuffer`) is compared byte-for-byte; everything else
+ * (including the `bodyBytes()` and other asymmetric matchers) falls through to
+ * structural `deepMatch`.
+ * @internal
+ */
+function matchBody(expected: unknown, actual: unknown): boolean {
+  if (isBinaryBody(expected)) {
+    return actual instanceof Uint8Array && bytesEqual(toBytes(expected), actual)
+  }
+  return deepMatch(expected, actual)
 }
 
 /**
@@ -389,7 +433,7 @@ function scoreMatch(
   }
 
   // Body match
-  if (handler.matchOptions.body === undefined || deepMatch(handler.matchOptions.body, body)) {
+  if (handler.matchOptions.body === undefined || matchBody(handler.matchOptions.body, body)) {
     score += 1
   }
 
@@ -463,7 +507,7 @@ function buildDiffs(
   }
 
   // Body diff
-  if (handler.matchOptions.body !== undefined && !deepMatch(handler.matchOptions.body, body)) {
+  if (handler.matchOptions.body !== undefined && !matchBody(handler.matchOptions.body, body)) {
     if (isRecord(handler.matchOptions.body) || Array.isArray(handler.matchOptions.body)) {
       diffs.push(...diffValues('body', handler.matchOptions.body, body))
     } else {
@@ -515,20 +559,30 @@ export function createMockFetch(): MockFetch {
       ? new Headers(init.headers)
       : new Headers(init?.headers ?? undefined)
 
-    // Parse body if content-type is JSON
+    // Parse / normalize the request body for recording and matching.
     let body: unknown = undefined
-    if (init?.body !== undefined && init.body !== null && typeof init.body === 'string') {
-      const ct = getContentType(normalizedHeaders)
-      if (ct !== null && ct.includes('application/json')) {
-        const result = tryParseJson(init.body)
-        if (result !== undefined) {
-          body = result.parsed
+    const rawBody = init?.body
+    if (rawBody !== undefined && rawBody !== null) {
+      if (typeof rawBody === 'string') {
+        const ct = getContentType(normalizedHeaders)
+        if (ct !== null && ct.includes('application/json')) {
+          const result = tryParseJson(rawBody)
+          body = result !== undefined ? result.parsed : rawBody
         } else {
-          body = init.body
+          body = rawBody
         }
-      } else {
-        body = init.body
+      } else if (rawBody instanceof Uint8Array || rawBody instanceof ArrayBuffer) {
+        // Store a defensive copy so the recorded body is a stable snapshot.
+        // Note: a plain `new Uint8Array(...)` copy is used rather than
+        // `toBytes(rawBody).slice()` because `Buffer` (a `Uint8Array`
+        // subclass) overrides `slice()` to return another `Buffer`, which
+        // `toEqual` treats as unequal to a plain `Uint8Array` snapshot.
+        body = new Uint8Array(toBytes(rawBody))
+      } else if (rawBody instanceof ReadableStream) {
+        body = await drainStream(rawBody)
       }
+      // Blob / FormData / URLSearchParams bodies are not yet normalized and
+      // remain unrecorded (body stays undefined).
     }
 
     // Record the request
@@ -556,7 +610,7 @@ export function createMockFetch(): MockFetch {
       if (!queryMatches(handler, query)) continue
 
       // Check body
-      if (handler.matchOptions.body !== undefined && !deepMatch(handler.matchOptions.body, body)) {
+      if (handler.matchOptions.body !== undefined && !matchBody(handler.matchOptions.body, body)) {
         continue
       }
 

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -163,6 +163,7 @@ async function drainStream(stream: ReadableStream): Promise<Uint8Array> {
   let total = 0
   for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
     const value: unknown = chunk.value
+    // Request-body streams yield binary chunks; anything else is ignored.
     if (value instanceof Uint8Array) {
       chunks.push(value)
       total += value.byteLength

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -1,5 +1,5 @@
 import type {FetchFunction, FetchResponse} from '../types'
-import {blobToBytes, contentTypeFor, normalizeExpectedBody} from './body'
+import {blobToBytes, contentTypeFor, normalizeExpectedBody, normalizeUrlSearchParams} from './body'
 import {bytesEqual, isBinaryBody, toBytes} from './bytes'
 import type {Diff} from './diff'
 import {diffValues} from './diff'
@@ -658,6 +658,8 @@ export function createMockFetch(): MockFetch {
       } else if (rawBody instanceof Blob) {
         // File extends Blob; a bare blob/file body sends only bytes on the wire.
         body = await blobToBytes(rawBody)
+      } else if (rawBody instanceof URLSearchParams) {
+        body = normalizeUrlSearchParams(rawBody)
       }
     }
 

--- a/src/mock/diff.ts
+++ b/src/mock/diff.ts
@@ -1,3 +1,4 @@
+import {bytesEqual} from './bytes'
 import {isAsymmetricMatcher, isRecord} from './matchers'
 
 /**
@@ -22,6 +23,13 @@ export function diffValues(prefix: string, expected: unknown, actual: unknown): 
   }
 
   if (expected === actual) return []
+
+  if (expected instanceof Uint8Array || actual instanceof Uint8Array) {
+    if (expected instanceof Uint8Array && actual instanceof Uint8Array && bytesEqual(expected, actual)) {
+      return []
+    }
+    return [{path: prefix, expected, actual}]
+  }
 
   if (
     typeof expected !== 'object' ||

--- a/src/mock/errors.ts
+++ b/src/mock/errors.ts
@@ -17,6 +17,7 @@ function formatValue(value: unknown): string {
   if (value === undefined) return 'undefined'
   if (typeof value === 'string') return `"${value}"`
   if (value instanceof Uint8Array) return `Uint8Array(${value.byteLength} bytes)`
+  if (value instanceof ArrayBuffer) return `ArrayBuffer(${value.byteLength} bytes)`
   return String(value)
 }
 

--- a/src/mock/errors.ts
+++ b/src/mock/errors.ts
@@ -16,6 +16,7 @@ export interface MockDescription {
 function formatValue(value: unknown): string {
   if (value === undefined) return 'undefined'
   if (typeof value === 'string') return `"${value}"`
+  if (value instanceof Uint8Array) return `Uint8Array(${value.byteLength} bytes)`
   return String(value)
 }
 

--- a/src/mock/matchers.ts
+++ b/src/mock/matchers.ts
@@ -47,6 +47,10 @@ export function deepMatch(expected: unknown, actual: unknown): boolean {
 
   if (expected === actual) return true
 
+  if (expected instanceof Uint8Array || actual instanceof Uint8Array) {
+    return expected instanceof Uint8Array && actual instanceof Uint8Array && bytesEqual(expected, actual)
+  }
+
   if (typeof expected !== typeof actual) return false
   if (expected === null || actual === null) return false
 

--- a/src/mock/matchers.ts
+++ b/src/mock/matchers.ts
@@ -101,16 +101,26 @@ export function objectContaining(expected: Record<string, unknown>): AsymmetricM
 /**
  * Matches a query object that contains at least the specified keys with matching
  * values. Expected values are coerced to strings before comparison, since query
- * parameters are always strings. Extra keys on the actual value are ignored.
+ * parameters are always strings. An array expected value matches a multi-value
+ * param (an array actual) that contains each expected value. Extra keys on the
+ * actual value are ignored.
  * @public
  */
 export function queryContaining(
-  expected: Record<string, string | number | boolean>,
+  expected: Record<string, string | number | boolean | Array<string | number | boolean>>,
 ): AsymmetricMatcher {
   return {
     asymmetricMatch(actual: unknown): boolean {
       if (!isRecord(actual)) return false
-      return Object.keys(expected).every((key) => actual[key] === String(expected[key]))
+      return Object.keys(expected).every((key) => {
+        const expectedValue = expected[key]
+        const actualValue = actual[key]
+        if (Array.isArray(expectedValue)) {
+          if (!Array.isArray(actualValue)) return false
+          return expectedValue.every((item) => actualValue.includes(String(item)))
+        }
+        return actualValue === String(expectedValue)
+      })
     },
   }
 }

--- a/src/mock/matchers.ts
+++ b/src/mock/matchers.ts
@@ -1,3 +1,5 @@
+import {bytesEqual, toBytes} from './bytes'
+
 /**
  * Protocol interface for asymmetric matching, compatible with vitest/Jest.
  * @public
@@ -136,4 +138,25 @@ export function arrayContaining(expected: unknown[]): AsymmetricMatcher {
       )
     },
   }
+}
+
+/**
+ * Matches a request body against exact bytes. The actual value must be a
+ * `Uint8Array` (which is how the mock records binary and streamed bodies) with
+ * identical bytes. Accepts a `Uint8Array` or `ArrayBuffer` as the expected value.
+ * @public
+ */
+export function bodyBytes(expected: Uint8Array | ArrayBuffer): AsymmetricMatcher {
+  const expectedBytes = toBytes(expected)
+  // Assigned to a variable (not returned as a literal) so the extra `toString`
+  // member doesn't trip TypeScript's excess-property check against AsymmetricMatcher.
+  const matcher = {
+    asymmetricMatch(actual: unknown): boolean {
+      return actual instanceof Uint8Array && bytesEqual(expectedBytes, actual)
+    },
+    toString(): string {
+      return `bodyBytes(${expectedBytes.byteLength} bytes)`
+    },
+  }
+  return matcher
 }

--- a/test/mock/body.test.ts
+++ b/test/mock/body.test.ts
@@ -1,0 +1,64 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  blobToBytes,
+  contentTypeFor,
+  normalizeExpectedBody,
+  normalizeFormData,
+  normalizeUrlSearchParams,
+} from '../../src/mock/body'
+
+describe('body normalization', () => {
+  describe('blobToBytes', () => {
+    it('reads a Blob into a Uint8Array', async () => {
+      expect(await blobToBytes(new Blob([new Uint8Array([1, 2, 3])]))).toEqual(new Uint8Array([1, 2, 3]))
+    })
+  })
+
+  describe('normalizeUrlSearchParams', () => {
+    it('single values are strings, duplicates become arrays', () => {
+      expect(normalizeUrlSearchParams(new URLSearchParams('a=1&b=2&b=3'))).toEqual({
+        a: '1',
+        b: ['2', '3'],
+      })
+    })
+  })
+
+  describe('normalizeFormData', () => {
+    it('normalizes string and file fields, grouping duplicates', async () => {
+      const form = new FormData()
+      form.append('title', 'Hi')
+      form.append('file', new File([new Uint8Array([1, 2])], 'a.png', {type: 'image/png'}))
+      form.append('tag', 'x')
+      form.append('tag', 'y')
+
+      expect(await normalizeFormData(form)).toEqual({
+        title: 'Hi',
+        file: {name: 'a.png', type: 'image/png', size: 2, bytes: new Uint8Array([1, 2])},
+        tag: ['x', 'y'],
+      })
+    })
+  })
+
+  describe('contentTypeFor', () => {
+    it('returns platform defaults for form/url bodies and blob type', () => {
+      expect(contentTypeFor(new URLSearchParams('a=1'))).toBe(
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      )
+      expect(contentTypeFor(new Blob(['x'], {type: 'image/png'}))).toBe('image/png')
+      expect(contentTypeFor(new Blob(['x']))).toBe(null)
+      expect(contentTypeFor('plain')).toBe(null)
+      const ct = contentTypeFor(new FormData())
+      expect(ct).toMatch(/^multipart\/form-data; boundary=/)
+    })
+  })
+
+  describe('normalizeExpectedBody', () => {
+    it('normalizes native body types and passes others through', async () => {
+      expect(await normalizeExpectedBody(new URLSearchParams('a=1'))).toEqual({a: '1'})
+      expect(await normalizeExpectedBody(new Blob([new Uint8Array([9])]))).toEqual(new Uint8Array([9]))
+      const passthrough = {title: 'Hi'}
+      expect(await normalizeExpectedBody(passthrough)).toBe(passthrough)
+    })
+  })
+})

--- a/test/mock/bytes.test.ts
+++ b/test/mock/bytes.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest'
+
+import {bytesEqual, isBinaryBody, toBytes} from '../../src/mock/bytes'
+
+describe('bytes helpers', () => {
+  describe('isBinaryBody', () => {
+    it('is true for Uint8Array and ArrayBuffer', () => {
+      expect(isBinaryBody(new Uint8Array([1, 2]))).toBe(true)
+      expect(isBinaryBody(new ArrayBuffer(2))).toBe(true)
+      expect(isBinaryBody(Buffer.from([1, 2]))).toBe(true)
+    })
+
+    it('is false for other values', () => {
+      expect(isBinaryBody('abc')).toBe(false)
+      expect(isBinaryBody({})).toBe(false)
+      expect(isBinaryBody([1, 2])).toBe(false)
+      expect(isBinaryBody(null)).toBe(false)
+      expect(isBinaryBody(undefined)).toBe(false)
+    })
+  })
+
+  describe('toBytes', () => {
+    it('passes a Uint8Array through', () => {
+      const input = new Uint8Array([1, 2, 3])
+      expect(toBytes(input)).toBe(input)
+    })
+
+    it('wraps an ArrayBuffer', () => {
+      const buffer = new Uint8Array([4, 5, 6]).buffer
+      expect(toBytes(buffer)).toEqual(new Uint8Array([4, 5, 6]))
+    })
+  })
+
+  describe('bytesEqual', () => {
+    it('is true for equal bytes', () => {
+      expect(bytesEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true)
+    })
+
+    it('is false for differing length', () => {
+      expect(bytesEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))).toBe(false)
+    })
+
+    it('is false for differing byte', () => {
+      expect(bytesEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 9, 3]))).toBe(false)
+    })
+  })
+})

--- a/test/mock/bytes.test.ts
+++ b/test/mock/bytes.test.ts
@@ -7,6 +7,11 @@ describe('bytes helpers', () => {
     it('is true for Uint8Array and ArrayBuffer', () => {
       expect(isBinaryBody(new Uint8Array([1, 2]))).toBe(true)
       expect(isBinaryBody(new ArrayBuffer(2))).toBe(true)
+    })
+
+    // `Buffer` is Node-only; skip in browser/edge/worker environments where it
+    // is undefined. It is a `Uint8Array` subclass, so it takes the same path.
+    it.skipIf(typeof Buffer === 'undefined')('is true for a Node Buffer', () => {
       expect(isBinaryBody(Buffer.from([1, 2]))).toBe(true)
     })
 

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1336,4 +1336,67 @@ describe('createMockFetch', () => {
       expect(mock.getRequests()[0].body).toEqual(new Uint8Array(0))
     })
   })
+
+  describe('headers matching', () => {
+    it('matches a header by plain record, case-insensitively', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/x', {headers: {'Content-Type': 'text/plain'}}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/x', {
+        method: 'POST',
+        headers: {'content-type': 'text/plain'},
+        body: 'hi',
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('matches with objectContaining + stringMatching', async () => {
+      const mock = createMockFetch()
+      mock
+        .on('POST', '/x', {headers: objectContaining({'content-type': stringMatching(/^text\//)})})
+        .respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/x', {
+        method: 'POST',
+        headers: {'content-type': 'text/plain'},
+        body: 'hi',
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('ignores unlisted headers (containing)', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/x', {headers: {'x-a': '1'}}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/x', {
+        method: 'POST',
+        headers: {'x-a': '1', 'x-b': '2'},
+        body: 'hi',
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('reports a headers diff on mismatch', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/x', {headers: {'x-a': '1'}}).respond({status: 200})
+
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/x', {
+          method: 'POST',
+          headers: {'x-a': '2'},
+          body: 'hi',
+        })
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(Error)
+      if (!(error instanceof Error)) throw new Error('expected an error')
+      expect(error.message).toContain('headers.x-a: expected "1", received "2"')
+    })
+  })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1404,6 +1404,60 @@ describe('createMockFetch', () => {
     })
   })
 
+  describe('URLSearchParams bodies', () => {
+    it('records as a record and matches a plain object', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/form', {body: {a: '1', b: '2'}}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/form', {
+        method: 'POST',
+        body: new URLSearchParams({a: '1', b: '2'}),
+      })
+
+      expect(res.status).toBe(200)
+      expect(mock.getRequests()[0].body).toEqual({a: '1', b: '2'})
+    })
+
+    it('matches by passing a URLSearchParams', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/form', {body: new URLSearchParams({a: '1'})}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/form', {
+        method: 'POST',
+        body: new URLSearchParams({a: '1'}),
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('preserves multi-value params as arrays and matches queryContaining', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/form', {body: queryContaining({tag: ['x', 'y']})}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/form', {
+        method: 'POST',
+        body: new URLSearchParams('tag=x&tag=y&other=1'),
+      })
+
+      expect(res.status).toBe(200)
+      expect(mock.getRequests()[0].body).toEqual({tag: ['x', 'y'], other: '1'})
+    })
+
+    it('synthesizes the form-urlencoded content-type', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/form').respond({status: 200})
+
+      await mock.fetch('https://api.example.com/form', {
+        method: 'POST',
+        body: new URLSearchParams({a: '1'}),
+      })
+
+      expect(mock.getRequests()[0].headers.get('content-type')).toBe(
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      )
+    })
+  })
+
   describe('headers matching', () => {
     it('matches a header by plain record, case-insensitively', async () => {
       const mock = createMockFetch()

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -7,6 +7,7 @@ import {MockFetchError} from '../../src/mock/errors'
 import {
   anyValue,
   arrayContaining,
+  bodyBytes,
   objectContaining,
   queryContaining,
   stringMatching,
@@ -1189,6 +1190,89 @@ describe('createMockFetch', () => {
       expect(error instanceof Error ? error.message : '').toContain(
         'Cannot combine a query string in the URL pattern',
       )
+    })
+  })
+
+  describe('binary request bodies', () => {
+    it('records and matches a Uint8Array body', async () => {
+      const mock = createMockFetch()
+      const bytes = new Uint8Array([1, 2, 3, 4])
+      mock.on('POST', '/upload', {body: bytes}).respond({status: 201})
+
+      const res = await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new Uint8Array([1, 2, 3, 4]),
+      })
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([1, 2, 3, 4]))
+    })
+
+    it('records and matches an ArrayBuffer body', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {body: new Uint8Array([9, 8, 7]).buffer}).respond({status: 201})
+
+      const res = await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new Uint8Array([9, 8, 7]).buffer,
+      })
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([9, 8, 7]))
+    })
+
+    it('records and matches a ReadableStream body', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {body: new Uint8Array([1, 2, 3, 4, 5])}).respond({status: 201})
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          controller.enqueue(new Uint8Array([4, 5]))
+          controller.close()
+        },
+      })
+
+      const res = await mock.fetch('https://api.example.com/upload', {method: 'POST', body: stream})
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([1, 2, 3, 4, 5]))
+    })
+
+    it('records and matches a Buffer body', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {body: new Uint8Array([10, 20])}).respond({status: 201})
+
+      const res = await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: Buffer.from([10, 20]),
+      })
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([10, 20]))
+    })
+
+    it('matches with the bodyBytes matcher', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {body: bodyBytes(new Uint8Array([1, 2, 3]))}).respond({status: 201})
+
+      const res = await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new Uint8Array([1, 2, 3]),
+      })
+
+      expect(res.status).toBe(201)
+    })
+
+    it('records a stable snapshot that later mutation cannot change', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload').respond({status: 201})
+
+      const source = new Uint8Array([1, 2, 3])
+      await mock.fetch('https://api.example.com/upload', {method: 'POST', body: source})
+      source[0] = 99
+
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([1, 2, 3]))
     })
   })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1254,7 +1254,9 @@ describe('createMockFetch', () => {
 
     it('matches with the bodyBytes matcher', async () => {
       const mock = createMockFetch()
-      mock.on('POST', '/upload', {body: bodyBytes(new Uint8Array([1, 2, 3]))}).respond({status: 201})
+      mock
+        .on('POST', '/upload', {body: bodyBytes(new Uint8Array([1, 2, 3]))})
+        .respond({status: 201})
 
       const res = await mock.fetch('https://api.example.com/upload', {
         method: 'POST',
@@ -1291,7 +1293,46 @@ describe('createMockFetch', () => {
 
       expect(error).toBeInstanceOf(Error)
       if (!(error instanceof Error)) throw new Error('expected an error')
-      expect(error.message).toContain('body: expected Uint8Array(3 bytes), received Uint8Array(4 bytes)')
+      expect(error.message).toContain(
+        'body: expected Uint8Array(3 bytes), received Uint8Array(4 bytes)',
+      )
+    })
+
+    it('renders a readable error when an ArrayBuffer body differs', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {body: new Uint8Array([1, 2, 3]).buffer}).respond({status: 201})
+
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/upload', {
+          method: 'POST',
+          body: new Uint8Array([9, 9, 9, 9]),
+        })
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(Error)
+      if (!(error instanceof Error)) throw new Error('expected an error')
+      expect(error.message).toContain(
+        'body: expected ArrayBuffer(3 bytes), received Uint8Array(4 bytes)',
+      )
+    })
+
+    it('records an empty ReadableStream body as an empty Uint8Array', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload').respond({status: 201})
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close()
+        },
+      })
+
+      const res = await mock.fetch('https://api.example.com/upload', {method: 'POST', body: stream})
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array(0))
     })
   })
 })

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1337,6 +1337,73 @@ describe('createMockFetch', () => {
     })
   })
 
+  describe('Blob and File bodies', () => {
+    it('records a Blob body as bytes and matches with bodyBytes', async () => {
+      const mock = createMockFetch()
+      mock
+        .on('POST', '/upload', {body: bodyBytes(new Uint8Array([1, 2, 3]))})
+        .respond({status: 201})
+
+      const res = await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new Blob([new Uint8Array([1, 2, 3])]),
+      })
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([1, 2, 3]))
+    })
+
+    it('synthesizes content-type from blob.type, assertable via headers', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {headers: {'content-type': 'image/png'}}).respond({status: 201})
+
+      const res = await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new Blob([new Uint8Array([1])], {type: 'image/png'}),
+      })
+
+      expect(res.status).toBe(201)
+      expect(mock.getRequests()[0].headers.get('content-type')).toBe('image/png')
+    })
+
+    it('does not synthesize content-type for a typeless Blob', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload').respond({status: 201})
+
+      await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new Blob([new Uint8Array([1])]),
+      })
+
+      expect(mock.getRequests()[0].headers.get('content-type')).toBe(null)
+    })
+
+    it('records a File body as bytes (name not recorded)', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload').respond({status: 201})
+
+      await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        body: new File([new Uint8Array([7, 8])], 'a.bin', {type: 'application/octet-stream'}),
+      })
+
+      expect(mock.getRequests()[0].body).toEqual(new Uint8Array([7, 8]))
+    })
+
+    it('does not override an explicit content-type', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload').respond({status: 201})
+
+      await mock.fetch('https://api.example.com/upload', {
+        method: 'POST',
+        headers: {'content-type': 'application/custom'},
+        body: new Blob([new Uint8Array([1])], {type: 'image/png'}),
+      })
+
+      expect(mock.getRequests()[0].headers.get('content-type')).toBe('application/custom')
+    })
+  })
+
   describe('headers matching', () => {
     it('matches a header by plain record, case-insensitively', async () => {
       const mock = createMockFetch()

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1239,7 +1239,8 @@ describe('createMockFetch', () => {
       expect(mock.getRequests()[0].body).toEqual(new Uint8Array([1, 2, 3, 4, 5]))
     })
 
-    it('records and matches a Buffer body', async () => {
+    // `Buffer` is Node-only; skip where it is undefined (browser/edge/worker).
+    it.skipIf(typeof Buffer === 'undefined')('records and matches a Buffer body', async () => {
       const mock = createMockFetch()
       mock.on('POST', '/upload', {body: new Uint8Array([10, 20])}).respond({status: 201})
 

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1458,6 +1458,103 @@ describe('createMockFetch', () => {
     })
   })
 
+  describe('FormData bodies', () => {
+    function buildForm() {
+      const form = new FormData()
+      form.append('title', 'Hi')
+      form.append('file', new File([new Uint8Array([1, 2])], 'a.png', {type: 'image/png'}))
+      return form
+    }
+
+    it('records a normalized field record', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/u').respond({status: 200})
+
+      await mock.fetch('https://api.example.com/u', {method: 'POST', body: buildForm()})
+
+      expect(mock.getRequests()[0].body).toEqual({
+        title: 'Hi',
+        file: {name: 'a.png', type: 'image/png', size: 2, bytes: new Uint8Array([1, 2])},
+      })
+    })
+
+    it('matches exactly by passing a FormData', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/u', {body: buildForm()}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/u', {method: 'POST', body: buildForm()})
+      expect(res.status).toBe(200)
+    })
+
+    it('fails an exact match when an extra field is present', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/u', {body: buildForm()}).respond({status: 200})
+
+      const extra = buildForm()
+      extra.append('surprise', 'x')
+
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/u', {method: 'POST', body: extra})
+      } catch (err) {
+        error = err
+      }
+      expect(error).toBeInstanceOf(Error)
+      if (!(error instanceof Error)) throw new Error('expected an error')
+      expect(error.message).toContain('No mock matched')
+    })
+
+    it('matches partially with objectContaining', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/u', {body: objectContaining({title: 'Hi'})}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/u', {method: 'POST', body: buildForm()})
+      expect(res.status).toBe(200)
+    })
+
+    it('matches a file part by name/type and bytes', async () => {
+      const mock = createMockFetch()
+      mock
+        .on('POST', '/u', {
+          body: objectContaining({
+            file: objectContaining({
+              name: 'a.png',
+              type: 'image/png',
+              bytes: bodyBytes(new Uint8Array([1, 2])),
+            }),
+          }),
+        })
+        .respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/u', {method: 'POST', body: buildForm()})
+      expect(res.status).toBe(200)
+    })
+
+    it('preserves multi-value fields as arrays', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/u').respond({status: 200})
+
+      const form = new FormData()
+      form.append('tag', 'x')
+      form.append('tag', 'y')
+      await mock.fetch('https://api.example.com/u', {method: 'POST', body: form})
+
+      expect(mock.getRequests()[0].body).toEqual({tag: ['x', 'y']})
+    })
+
+    it('synthesizes a multipart content-type with a boundary', async () => {
+      const mock = createMockFetch()
+      mock
+        .on('POST', '/u', {
+          headers: {'content-type': stringMatching(/^multipart\/form-data; boundary=/)},
+        })
+        .respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/u', {method: 'POST', body: buildForm()})
+      expect(res.status).toBe(200)
+    })
+  })
+
   describe('headers matching', () => {
     it('matches a header by plain record, case-insensitively', async () => {
       const mock = createMockFetch()

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1274,5 +1274,24 @@ describe('createMockFetch', () => {
 
       expect(mock.getRequests()[0].body).toEqual(new Uint8Array([1, 2, 3]))
     })
+
+    it('renders a readable error when binary bodies differ', async () => {
+      const mock = createMockFetch()
+      mock.on('POST', '/upload', {body: new Uint8Array([1, 2, 3])}).respond({status: 201})
+
+      let error: unknown
+      try {
+        await mock.fetch('https://api.example.com/upload', {
+          method: 'POST',
+          body: new Uint8Array([9, 9, 9, 9]),
+        })
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(Error)
+      if (!(error instanceof Error)) throw new Error('expected an error')
+      expect(error.message).toContain('body: expected Uint8Array(3 bytes), received Uint8Array(4 bytes)')
+    })
   })
 })

--- a/test/mock/diff.test.ts
+++ b/test/mock/diff.test.ts
@@ -42,3 +42,16 @@ describe('diffValues', () => {
     expect(diffs).toEqual([{path: 'query.limit', expected: '10', actual: '20'}])
   })
 })
+
+describe('diffValues with Uint8Array', () => {
+  it('returns no diff for equal bytes', () => {
+    expect(diffValues('body', new Uint8Array([1, 2]), new Uint8Array([1, 2]))).toEqual([])
+  })
+
+  it('returns a single diff for differing bytes', () => {
+    const diffs = diffValues('body', new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))
+    expect(diffs).toEqual([
+      {path: 'body', expected: new Uint8Array([1, 2]), actual: new Uint8Array([1, 2, 3])},
+    ])
+  })
+})

--- a/test/mock/matchers.test.ts
+++ b/test/mock/matchers.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, it} from 'vitest'
 import {
   anyValue,
   arrayContaining,
+  bodyBytes,
   deepMatch,
   isAsymmetricMatcher,
   objectContaining,
@@ -183,5 +184,33 @@ describe('queryContaining', () => {
   it('rejects non-record input', () => {
     expect(queryContaining({a: 1}).asymmetricMatch(null)).toBe(false)
     expect(queryContaining({a: 1}).asymmetricMatch('a=1')).toBe(false)
+  })
+})
+
+describe('bodyBytes', () => {
+  it('matches a Uint8Array with equal bytes', () => {
+    expect(bodyBytes(new Uint8Array([1, 2, 3])).asymmetricMatch(new Uint8Array([1, 2, 3]))).toBe(
+      true,
+    )
+  })
+
+  it('rejects differing bytes', () => {
+    expect(bodyBytes(new Uint8Array([1, 2, 3])).asymmetricMatch(new Uint8Array([1, 9, 3]))).toBe(
+      false,
+    )
+  })
+
+  it('rejects a non-Uint8Array actual', () => {
+    expect(bodyBytes(new Uint8Array([1, 2, 3])).asymmetricMatch('123')).toBe(false)
+    expect(bodyBytes(new Uint8Array([1, 2, 3])).asymmetricMatch(new ArrayBuffer(3))).toBe(false)
+  })
+
+  it('accepts an ArrayBuffer as the expected value', () => {
+    const buffer = new Uint8Array([7, 8, 9]).buffer
+    expect(bodyBytes(buffer).asymmetricMatch(new Uint8Array([7, 8, 9]))).toBe(true)
+  })
+
+  it('has a readable toString', () => {
+    expect(String(bodyBytes(new Uint8Array([1, 2, 3])))).toBe('bodyBytes(3 bytes)')
   })
 })

--- a/test/mock/matchers.test.ts
+++ b/test/mock/matchers.test.ts
@@ -185,6 +185,26 @@ describe('queryContaining', () => {
     expect(queryContaining({a: 1}).asymmetricMatch(null)).toBe(false)
     expect(queryContaining({a: 1}).asymmetricMatch('a=1')).toBe(false)
   })
+
+  it('matches an array-valued param (containing)', () => {
+    expect(queryContaining({tags: ['a', 'b']}).asymmetricMatch({tags: ['a', 'b', 'c']})).toBe(true)
+  })
+
+  it('rejects an array param when a value is missing', () => {
+    expect(queryContaining({tags: ['a', 'z']}).asymmetricMatch({tags: ['a', 'b']})).toBe(false)
+  })
+
+  it('rejects an array expected against a scalar actual', () => {
+    expect(queryContaining({tags: ['a']}).asymmetricMatch({tags: 'a'})).toBe(false)
+  })
+
+  it('coerces array element types', () => {
+    expect(queryContaining({ids: [1, 2]}).asymmetricMatch({ids: ['1', '2']})).toBe(true)
+  })
+
+  it('still matches scalar params (unchanged)', () => {
+    expect(queryContaining({limit: 10}).asymmetricMatch({limit: '10'})).toBe(true)
+  })
 })
 
 describe('bodyBytes', () => {

--- a/test/mock/matchers.test.ts
+++ b/test/mock/matchers.test.ts
@@ -214,3 +214,28 @@ describe('bodyBytes', () => {
     expect(String(bodyBytes(new Uint8Array([1, 2, 3])))).toBe('bodyBytes(3 bytes)')
   })
 })
+
+describe('deepMatch with Uint8Array', () => {
+  it('matches equal byte arrays', () => {
+    expect(deepMatch(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true)
+  })
+
+  it('rejects differing byte arrays', () => {
+    expect(deepMatch(new Uint8Array([1, 2, 3]), new Uint8Array([1, 9, 3]))).toBe(false)
+    expect(deepMatch(new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))).toBe(false)
+  })
+
+  it('rejects a Uint8Array against a non-Uint8Array', () => {
+    expect(deepMatch(new Uint8Array([1]), {0: 1})).toBe(false)
+    expect(deepMatch({0: 1}, new Uint8Array([1]))).toBe(false)
+  })
+
+  it('matches nested bytes inside an object', () => {
+    expect(
+      deepMatch({name: 'a', bytes: new Uint8Array([1, 2])}, {name: 'a', bytes: new Uint8Array([1, 2])}),
+    ).toBe(true)
+    expect(
+      deepMatch({name: 'a', bytes: new Uint8Array([1, 2])}, {name: 'a', bytes: new Uint8Array([9, 9])}),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
### Description

It's very tedious to match binary bodies currently - `createMockFetch` only captures a body if it's a string.

Currently you have to do something like wrapping `mock.fetch`, draining/normalizing the body to a hex string before matching (or some other hacky approach):

```ts
const wrapped = async (url, init) => {
  let body = init?.body
  if (body instanceof ReadableStream) body = bytesToHex(await drain(body))
  else if (body instanceof Uint8Array || body instanceof ArrayBuffer) body = bytesToHex(toBytes(body))
  return mock.fetch(url, init ? {...init, body} : init)
}
// matcher:
mock.on('POST', '/upload', {
  body: {asymmetricMatch: (b) => Buffer.from(b, 'hex').compare(fileBytes) === 0},
})
```

The logical addition here is to extend our matchers to support binary bodies. Follows the same pattern as other matchers - you just pass it a Uint8Array or ArrayBuffer as `body`, and it will try to match it. This works even if the body was sent as a ReadableStream.

Once binary was in place the same gap applied to the rest of the `FetchBody` types, so this PR now covers all of them. Same idea throughout: the body is normalized to a plain value on record, and you can pass the native type straight in as the matcher.

- **`Blob` / `File`** - recorded as bytes, so you match them with `bodyBytes()` (or a raw Uint8Array), same as the binary case. The filename isn't recorded since it isn't actually sent for a bare body, but the content-type is synthesized from `blob.type` so you can still assert it (see `headers` below).
- **`FormData`** - normalized to a plain field record (file parts become `{name, type, size, bytes}`, repeated fields become arrays). Pass a `FormData` as `body` for an exact match, or `objectContaining(...)` for a partial one. No multipart boundary to reason about.
- **`URLSearchParams`** - normalized to a record, matchable with a plain object, `objectContaining`, or `queryContaining`.

Couple of things that fell out of the above:

- A `headers` match option - case-insensitive and only asserts the headers you list. This is also how you assert a synthesized content-type (e.g. that a `Blob` upload went out as `image/png`, or a `FormData` body as `multipart/form-data`).
- `queryContaining` now accepts arrays, for params (or `URLSearchParams` fields) that appear more than once.

It all reuses the existing matcher vocabulary, and works across Node, edge, workers and the browser.

### What to review

- Code makes sense?
- API design looks right?
