### PR TITLE
docs(types): warn that redirect:'manual' is opaque in browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,22 @@ res.body // ReadableStream<Uint8Array>
 
 ### Per-request options
 
-| Option       | Type                                                       | Description                                    |
-| ------------ | ---------------------------------------------------------- | ---------------------------------------------- |
-| `url`        | `string`                                                   | Request URL (required)                         |
-| `method`     | `string`                                                   | HTTP method                                    |
-| `body`       | `unknown`                                                  | Request body (objects auto-serialized as JSON) |
-| `headers`    | `FetchHeaders`                                             | Merged with instance headers                   |
-| `query`      | `Record<string, string \| number \| boolean \| undefined>` | URL query parameters                           |
-| `as`         | `'json' \| 'text' \| 'stream'`                             | Response body type                             |
-| `signal`     | `AbortSignal`                                              | Cancellation signal                            |
-| `httpErrors` | `boolean`                                                  | Override instance setting                      |
-| `timeout`    | `number \| false`                                          | Override instance timeout                      |
-| `fetch`      | `FetchFunction`                                            | Override instance fetch                        |
+| Option        | Type                                                       | Description                                                     |
+| ------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
+| `url`         | `string`                                                   | Request URL (required)                                          |
+| `method`      | `string`                                                   | HTTP method                                                     |
+| `body`        | `unknown`                                                  | Request body (objects auto-serialized as JSON)                  |
+| `headers`     | `FetchHeaders`                                             | Merged with instance headers                                    |
+| `query`       | `Record<string, string \| number \| boolean \| undefined>` | URL query parameters                                            |
+| `as`          | `'json' \| 'text' \| 'stream'`                             | Response body type                                              |
+| `signal`      | `AbortSignal`                                              | Cancellation signal                                             |
+| `httpErrors`  | `boolean`                                                  | Override instance setting                                       |
+| `timeout`     | `number \| false`                                          | Override instance timeout                                       |
+| `fetch`       | `FetchFunction`                                            | Override instance fetch                                         |
+| `redirect`    | `'error' \| 'follow' \| 'manual'`                          | Redirect strategy (`'manual'` is opaque in browsers - see note) |
+| `credentials` | `'include' \| 'omit' \| 'same-origin'`                     | Credentials mode (browser-only)                                 |
+
+> **Note on `redirect: 'manual'`:** In browsers this yields an opaque-redirect response (status `0`, empty headers) per the Fetch spec, so the 3xx status and headers (e.g. `location`) are unreadable. Reading them neither throws nor warns - `headers.get()` returns `null` and iteration is empty - so detect the case via `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes, workers) return the real 3xx response, so its status and headers are readable.
 
 ## Error handling
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,16 @@ export interface FetchInit {
   body?: FetchBody | null
   /** Abort signal for cancellation. */
   signal?: AbortSignal
-  /** Redirect handling strategy. */
+  /**
+   * Redirect handling strategy.
+   *
+   * ⚠️ In browsers, `'manual'` yields an opaque-redirect response (status `0`,
+   * empty headers) per the Fetch spec — you cannot read the status or headers
+   * (e.g. `location`) of the 3xx response. Reading them throws nothing and warns
+   * nothing: `headers.get()` returns `null` and iteration is empty. Detect it via
+   * `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes,
+   * workers) return the real 3xx response, so its status and headers are readable.
+   */
   redirect?: 'error' | 'follow' | 'manual'
   /** Credentials mode (browser-only — some runtimes crash if set). */
   credentials?: 'include' | 'omit' | 'same-origin'
@@ -154,7 +163,16 @@ export interface RequestOptions {
   fetch?: FetchFunction
   /** Credentials mode forwarded to fetch (browser-only). */
   credentials?: 'include' | 'omit' | 'same-origin'
-  /** Redirect handling strategy. */
+  /**
+   * Redirect handling strategy.
+   *
+   * ⚠️ In browsers, `'manual'` yields an opaque-redirect response (status `0`,
+   * empty headers) per the Fetch spec — you cannot read the status or headers
+   * (e.g. `location`) of the 3xx response. Reading them throws nothing and warns
+   * nothing: `headers.get()` returns `null` and iteration is empty. Detect it via
+   * `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes,
+   * workers) return the real 3xx response, so its status and headers are readable.
+   */
   redirect?: 'error' | 'follow' | 'manual'
   /** Arbitrary metadata — not used by get-it, but available to middleware. */
   meta?: {

--- a/test/redirect-manual.test.ts
+++ b/test/redirect-manual.test.ts
@@ -1,0 +1,41 @@
+import {createRequester} from 'get-it'
+import {describe, expect, it} from 'vitest'
+
+const baseUrl = 'http://localhost:9980/req-test'
+
+// Real-request coverage for `redirect: 'manual'` against an actual 302.
+// The pass-through tests in built-ins.test.ts assert the option reaches fetch;
+// this asserts get-it surfaces the runtime's real response without choking on
+// either shape. The observed behavior splits cleanly:
+//
+//   - Real browsers (Chromium/Firefox/WebKit) return an opaque-redirect
+//     filtered response per the Fetch spec: status 0, headers stripped.
+//   - Every non-browser runtime (Node/undici, Bun, Deno, edge runtimes,
+//     workers) and the happy-dom simulation return the real 3xx response
+//     with readable headers.
+//
+// We branch on the response signature (status 0 == opaque) rather than
+// sniffing the environment, so the same test asserts the correct contract
+// wherever it runs.
+describe('createRequester - redirect: manual', () => {
+  const request = createRequester()
+
+  it('surfaces the runtime redirect response without throwing', async () => {
+    const res = await request({
+      url: `${baseUrl}/redirect?n=0`,
+      redirect: 'manual',
+      httpErrors: false,
+    })
+
+    if (res.status === 0) {
+      // Opaque-redirect response (real browsers): nothing is readable.
+      expect(res.headers.get('location')).toBeNull()
+      expect([...res.headers.keys()]).toHaveLength(0)
+    } else {
+      // Real 3xx response (all non-browser runtimes): headers are readable
+      // and the redirect was not followed.
+      expect(res.status).toBe(302)
+      expect(res.headers.get('location')).toBe('/req-test/redirect?n=1')
+    }
+  })
+})


### PR DESCRIPTION
In browsers, `redirect: 'manual'` yields an opaque-redirect response (status 0, empty headers) per the Fetch spec - so the 3xx status and headers (e.g. `location`) are unreadable. Node.js (undici) returns the real 3xx response.

This PR adds a warning on both `FetchInit.redirect` and `RequestOptions.redirect` that users will (hopefully) see. This isn't a "don't use", but more of a "be careful". Tests added for completeness, but also to discover what different environments do. It seems all envs except browsers expose it (would have expected happy-dom to mirror browser behavior, so will open an issue and/or PR there if I have time)

Also adds the property to the README, as it was missing - as was `credentials` (browser-only property, unrelated but tedious to open a separate PR for).
