### PR TITLE
feat: structured timeout support ({total, headers})

### DIFF
--- a/.changeset/structured-timeouts.md
+++ b/.changeset/structured-timeouts.md
@@ -1,0 +1,5 @@
+---
+'get-it': minor
+---
+
+Add structured timeout support: `timeout` now also accepts `{total?, headers?}` alongside the existing `number | false` forms. `headers` limits time-to-response-headers per fetch attempt and throws the new exported `TimeoutError` (`code: 'ETIMEDOUT'`), which the default `retry()` middleware retries on GET/HEAD. Streaming callers can combine `{headers: 15_000, total: false}` with `retry()` instead of hand-rolling timeout middleware.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const request = createRequester({
 })
 ```
 
-- `total` — the existing deadline, implemented via `AbortSignal.timeout()`. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with the platform's `TimeoutError` DOMException.
+- `total` — the existing deadline, implemented via `AbortSignal.timeout()`. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with the platform's `TimeoutError` DOMException. When combined with the retry() middleware, the deadline applies per attempt - each retry gets a fresh total timer.
 - `headers` — time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. Because the timer lives inside the middleware chain, each retry attempt gets a fresh timer — no middleware ordering requirements.
 
 For long-running streaming downloads, disable the total deadline and keep a headers timeout:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const request = createRequester({
 })
 ```
 
-- `total` — the existing deadline, implemented via `AbortSignal.timeout()`. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with the platform's `TimeoutError` DOMException. When combined with the retry() middleware, the deadline applies per attempt - each retry gets a fresh total timer.
+- `total` — the existing deadline. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with a `TimeoutError` DOMException, which the `retry()` middleware never retries. When combined with the retry() middleware, the deadline applies per attempt - each retry gets a fresh total timer.
 - `headers` — time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. Because the timer lives inside the middleware chain, each retry attempt gets a fresh timer — no middleware ordering requirements.
 
 For long-running streaming downloads, disable the total deadline and keep a headers timeout:

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ res.body // ReadableStream<Uint8Array>
 
 ### Instance options (`createRequester`)
 
-| Option       | Type              | Default            | Description                                |
-| ------------ | ----------------- | ------------------ | ------------------------------------------ |
-| `base`       | `string`          | —                  | Base URL prepended to relative paths       |
-| `headers`    | `FetchHeaders`    | —                  | Default headers for all requests           |
-| `httpErrors` | `boolean`         | `true`             | Throw `HttpError` on status >= 400         |
-| `timeout`    | `number \| false` | —                  | Timeout in ms (uses `AbortSignal.timeout`) |
-| `fetch`      | `FetchFunction`   | `globalThis.fetch` | Custom fetch implementation                |
-| `middleware` | `Array`           | `[]`               | Transform and wrapping middleware          |
+| Option       | Type                                | Default            | Description                                                      |
+| ------------ | ----------------------------------- | ------------------ | ---------------------------------------------------------------- |
+| `base`       | `string`                            | —                  | Base URL prepended to relative paths                             |
+| `headers`    | `FetchHeaders`                      | —                  | Default headers for all requests                                 |
+| `httpErrors` | `boolean`                           | `true`             | Throw `HttpError` on status >= 400                               |
+| `timeout`    | `number \| false \| TimeoutOptions` | —                  | Timeout in ms, or `{total, headers}` — see [Timeouts](#timeouts) |
+| `fetch`      | `FetchFunction`                     | `globalThis.fetch` | Custom fetch implementation                                      |
+| `middleware` | `Array`                             | `[]`               | Transform and wrapping middleware                                |
 
 ### Per-request options
 
@@ -106,12 +106,41 @@ res.body // ReadableStream<Uint8Array>
 | `as`          | `'json' \| 'text' \| 'stream'`                             | Response body type                                              |
 | `signal`      | `AbortSignal`                                              | Cancellation signal                                             |
 | `httpErrors`  | `boolean`                                                  | Override instance setting                                       |
-| `timeout`     | `number \| false`                                          | Override instance timeout                                       |
+| `timeout`     | `number \| false \| TimeoutOptions`                        | Override instance timeout (replaces it wholesale)               |
 | `fetch`       | `FetchFunction`                                            | Override instance fetch                                         |
 | `redirect`    | `'error' \| 'follow' \| 'manual'`                          | Redirect strategy (`'manual'` is opaque in browsers - see note) |
 | `credentials` | `'include' \| 'omit' \| 'same-origin'`                     | Credentials mode (browser-only)                                 |
 
 > **Note on `redirect: 'manual'`:** In browsers this yields an opaque-redirect response (status `0`, empty headers) per the Fetch spec, so the 3xx status and headers (e.g. `location`) are unreadable. Reading them neither throws nor warns - `headers.get()` returns `null` and iteration is empty - so detect the case via `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes, workers) return the real 3xx response, so its status and headers are readable.
+
+## Timeouts
+
+`timeout` accepts a total deadline in milliseconds, `false` to disable, or a structured object:
+
+```ts
+const request = createRequester({
+  timeout: {
+    total: 120_000, // total deadline, request start through body (default 120 000)
+    headers: 15_000, // max time to receive response headers, per attempt (disabled by default)
+  },
+})
+```
+
+- `total` — the existing deadline, implemented via `AbortSignal.timeout()`. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with the platform's `TimeoutError` DOMException.
+- `headers` — time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. Because the timer lives inside the middleware chain, each retry attempt gets a fresh timer — no middleware ordering requirements.
+
+For long-running streaming downloads, disable the total deadline and keep a headers timeout:
+
+```ts
+import {createRequester} from 'get-it'
+import {retry} from 'get-it/middleware'
+
+const request = createRequester({
+  middleware: [retry()],
+  timeout: {headers: 15_000, total: false},
+})
+const res = await request({url: 'https://example.com/big-file', as: 'stream'})
+```
 
 ## Error handling
 

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -475,10 +475,10 @@ Since v9.2, `timeout` also accepts a structured object for finer control:
 await request({url: '/slow', timeout: {headers: 5000}})
 ```
 
-| v8                   | v9                                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------------- |
-| `timeout: {connect}` | `timeout: {headers}` — per-attempt time to response headers, throws a retryable `TimeoutError`          |
-| `timeout: {socket}`  | No direct equivalent (no idle/stall detection). Use `total` as a blunt substitute, or watch the stream. |
+| v8                   | v9                                                                                                                                                             |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timeout: {connect}` | `timeout: {headers}` — per-attempt time to response headers, throws a retryable `TimeoutError`                                                                 |
+| `timeout: {socket}`  | No direct equivalent (no idle/stall detection). Use `total` as a blunt substitute (note: per retry attempt when combined with `retry()`), or watch the stream. |
 
 For streaming downloads that should never hit a total deadline but fail fast on unresponsive servers:
 

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -467,6 +467,30 @@ await request({url: '/slow', timeout: 5000})
 await request({url: '/slow', timeout: false})
 ```
 
+Since v9.2, `timeout` also accepts a structured object for finer control:
+
+```ts
+// v8: timeout: {connect: 5000, socket: 30000}
+// v9 equivalent for the connect half:
+await request({url: '/slow', timeout: {headers: 5000}})
+```
+
+| v8                   | v9                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| `timeout: {connect}` | `timeout: {headers}` — per-attempt time to response headers, throws a retryable `TimeoutError`          |
+| `timeout: {socket}`  | No direct equivalent (no idle/stall detection). Use `total` as a blunt substitute, or watch the stream. |
+
+For streaming downloads that should never hit a total deadline but fail fast on unresponsive servers:
+
+```ts
+import {retry} from 'get-it/middleware'
+
+const request = createRequester({
+  middleware: [retry()],
+  timeout: {headers: 15_000, total: false},
+})
+```
+
 The timeout signal is automatically combined with any user-provided `signal` using `AbortSignal.any()`.
 
 **React Native**: v8 detected React Native (`navigator.product === 'ReactNative'`) and used a 60s default timeout. v9 uses 120s everywhere. To restore the shorter timeout:

--- a/src/_exports/index.node.ts
+++ b/src/_exports/index.node.ts
@@ -56,6 +56,7 @@ export type {
   RequestOptions,
   StreamResponse,
   TextResponse,
+  TimeoutOptions,
   TransformMiddleware,
   WrappingMiddleware,
 } from '../types'

--- a/src/_exports/index.node.ts
+++ b/src/_exports/index.node.ts
@@ -42,7 +42,7 @@ export function createRequester(
 }
 
 // Re-export everything from core
-export {HttpError} from '../errors'
+export {HttpError, TimeoutError} from '../errors'
 export type {
   BufferedResponse,
   DefaultResponse,

--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -13,6 +13,7 @@ export type {
   RequestOptions,
   StreamResponse,
   TextResponse,
+  TimeoutOptions,
   TransformMiddleware,
   WrappingMiddleware,
 } from '../types'

--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -1,5 +1,5 @@
 export {createRequester} from '../createRequester'
-export {HttpError} from '../errors'
+export {HttpError, TimeoutError} from '../errors'
 export type {
   BufferedResponse,
   DefaultResponse,

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -85,15 +85,26 @@ export function createRequester(
     // rather than an empty timer-callback stack.
     const timeoutError = new TimeoutError({url, method, timeoutMs: headersMs, phase: 'headers'})
     const controller = new AbortController()
-    const timer: ReturnType<typeof setTimeout> = setTimeout(
-      () => controller.abort(timeoutError),
-      headersMs,
-    )
+    // Reject via Promise.race rather than relying on fetch to reject with the
+    // abort reason: workerd's fetch reconstructs the reason (losing its
+    // prototype, so `instanceof TimeoutError` breaks), and WebKit has dropped
+    // the reason — or ignored `AbortSignal.any`-derived aborts entirely.
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timedOut = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(timeoutError)
+        controller.abort(timeoutError)
+      }, headersMs)
+    })
     const signal = init.signal
       ? AbortSignal.any([init.signal, controller.signal])
       : controller.signal
     try {
-      return {response: await fetchFn(url, {...init, signal}), url, method}
+      const fetching = Promise.resolve(fetchFn(url, {...init, signal}))
+      // If the timeout wins the race, the aborted fetch's later rejection
+      // must not become an unhandled rejection.
+      fetching.catch(() => {})
+      return {response: await Promise.race([fetching, timedOut]), url, method}
     } finally {
       clearTimeout(timer)
     }

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -283,6 +283,21 @@ function enabledMs(value: number | false | undefined): number | undefined {
   return value
 }
 
+/**
+ * Prevents a pending deadline timer from holding the Node.js event loop open
+ * for the full timeout window; no-op on platforms without timer.unref().
+ */
+function unrefTimer(timer: unknown): void {
+  if (
+    typeof timer === 'object' &&
+    timer !== null &&
+    'unref' in timer &&
+    typeof timer.unref === 'function'
+  ) {
+    timer.unref()
+  }
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null) return false
   if (Array.isArray(value)) return false
@@ -403,12 +418,21 @@ function buildFetchArgs(
   // Signal — build the final abort signal (totalMs already resolved by resolveTimeout)
   let signal: AbortSignal | undefined = opts.signal
   if (totalMs !== undefined) {
-    const timeoutSignal = AbortSignal.timeout(totalMs)
-    if (signal) {
-      signal = AbortSignal.any([signal, timeoutSignal])
-    } else {
-      signal = timeoutSignal
-    }
+    // Own the deadline timer instead of using AbortSignal.timeout(): WebKit
+    // can garbage-collect an otherwise-unreferenced timeout signal behind
+    // AbortSignal.any(), silently disarming the deadline. The timer callback
+    // closure keeps this controller (and thus the abort chain) alive.
+    const totalController = new AbortController()
+    unrefTimer(
+      setTimeout(
+        () =>
+          totalController.abort(
+            new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
+          ),
+        totalMs,
+      ),
+    )
+    signal = signal ? AbortSignal.any([signal, totalController.signal]) : totalController.signal
   }
   if (signal) init.signal = signal
 

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -1,4 +1,4 @@
-import {HttpError} from './errors'
+import {HttpError, TimeoutError} from './errors'
 import {createBufferedResponse} from './response'
 import type {
   BufferedResponse,
@@ -63,15 +63,51 @@ export function createRequester(
   }
 
   /**
+   * Builds fetch args, applies the headers-phase timeout when configured,
+   * and performs the fetch. Lives inside the wrapping-middleware chain, so
+   * each retry() attempt gets a fresh headers timer.
+   */
+  async function performFetch(
+    fetchFn: FetchFunction,
+    opts: RequestOptions,
+  ): Promise<{response: FetchResponse; url: string; method: string}> {
+    const {totalMs, headersMs} = resolveTimeout(
+      opts.timeout !== undefined ? opts.timeout : instanceTimeout,
+    )
+    const {url, init} = buildFetchArgs(opts, totalMs, instanceCredentials)
+    const method = init.method ?? 'GET'
+
+    if (headersMs === undefined) {
+      return {response: await fetchFn(url, init), url, method}
+    }
+
+    // Created eagerly so the stack trace points at the request call site
+    // rather than an empty timer-callback stack.
+    const timeoutError = new TimeoutError({url, method, timeoutMs: headersMs, phase: 'headers'})
+    const controller = new AbortController()
+    const timer: ReturnType<typeof setTimeout> = setTimeout(
+      () => controller.abort(timeoutError),
+      headersMs,
+    )
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, controller.signal])
+      : controller.signal
+    try {
+      return {response: await fetchFn(url, {...init, signal}), url, method}
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  /**
    * Core fetch + buffer function. This is the innermost layer
    * that wrapping middlewares eventually call.
    */
   async function getItBuffered(opts: RequestOptions): Promise<BufferedResponse> {
     const fetchFn: FetchFunction = opts.fetch ?? instanceFetch ?? globalThis.fetch
-    const {url, init} = buildFetchArgs(opts, instanceTimeout, instanceCredentials)
-    const response = await fetchFn(url, init)
+    const {response, url, method} = await performFetch(fetchFn, opts)
     const httpErrors = opts.httpErrors ?? instanceHttpErrors ?? true
-    return bufferAndCheck(response, httpErrors, url, init.method ?? 'GET')
+    return bufferAndCheck(response, httpErrors, url, method)
   }
 
   // Compose wrapping middlewares around the core fetch
@@ -115,12 +151,11 @@ export function createRequester(
 
     async function getItStreamed(reqOpts: RequestOptions): Promise<BufferedResponse> {
       const fetchFn: FetchFunction = reqOpts.fetch ?? instanceFetch ?? globalThis.fetch
-      const {url, init} = buildFetchArgs(reqOpts, instanceTimeout, instanceCredentials)
-      const response = await fetchFn(url, init)
+      const {response, url, method} = await performFetch(fetchFn, reqOpts)
       const httpErrors = reqOpts.httpErrors ?? instanceHttpErrors ?? true
 
       if (httpErrors && response.status >= 400) {
-        return bufferAndCheck(response, httpErrors, url, init.method ?? 'GET')
+        return bufferAndCheck(response, httpErrors, url, method)
       }
 
       capturedResponse = response
@@ -194,6 +229,7 @@ export function createRequester(
     }
   }
 
+  defineFnName(performFetch, 'performFetch')
   defineFnName(getItBuffered, 'getItBuffered')
   defineFnName(requestStream, 'requestStream')
   defineFnName(requestJson, 'requestJson')
@@ -300,7 +336,7 @@ function mergeHeaders(
  */
 function buildFetchArgs(
   opts: RequestOptions,
-  instanceTimeout: number | false | TimeoutOptions | undefined,
+  totalMs: number | undefined,
   instanceCredentials: 'include' | 'omit' | 'same-origin' | undefined,
 ): {url: string; init: FetchInit} {
   let url = opts.url
@@ -353,13 +389,10 @@ function buildFetchArgs(
 
   init.headers = headers
 
-  // Timeout — resolve timeout value (per-request wins over instance, default 120s)
-  const timeoutValue = opts.timeout !== undefined ? opts.timeout : (instanceTimeout ?? 120_000)
-
-  // Signal — build the final abort signal
+  // Signal — build the final abort signal (totalMs already resolved by resolveTimeout)
   let signal: AbortSignal | undefined = opts.signal
-  if (typeof timeoutValue === 'number' && timeoutValue > 0) {
-    const timeoutSignal = AbortSignal.timeout(timeoutValue)
+  if (totalMs !== undefined) {
+    const timeoutSignal = AbortSignal.timeout(totalMs)
     if (signal) {
       signal = AbortSignal.any([signal, timeoutSignal])
     } else {

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -13,6 +13,7 @@ import type {
   RequestOptions,
   StreamResponse,
   TextResponse,
+  TimeoutOptions,
   TransformMiddleware,
   WrappingMiddleware,
 } from './types'
@@ -202,6 +203,39 @@ export function createRequester(
   return request
 }
 
+/**
+ * Resolved per-request timeout configuration. `undefined` means the phase
+ * is disabled.
+ * @internal
+ */
+export interface ResolvedTimeout {
+  totalMs: number | undefined
+  headersMs: number | undefined
+}
+
+/**
+ * Normalizes a `timeout` option value into per-phase millisecond values.
+ * `false` and values <= 0 disable a phase; an omitted `total` falls back to
+ * the 120 000 ms default. A plain number or `false` is total-only shorthand.
+ * @internal
+ */
+export function resolveTimeout(
+  value: number | false | TimeoutOptions | undefined,
+): ResolvedTimeout {
+  if (typeof value === 'number' || value === false) {
+    return {totalMs: enabledMs(value), headersMs: undefined}
+  }
+  return {
+    totalMs: value?.total === undefined ? 120_000 : enabledMs(value.total),
+    headersMs: enabledMs(value?.headers),
+  }
+}
+
+function enabledMs(value: number | false | undefined): number | undefined {
+  if (value === undefined || value === false || value <= 0) return undefined
+  return value
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null) return false
   if (Array.isArray(value)) return false
@@ -266,7 +300,7 @@ function mergeHeaders(
  */
 function buildFetchArgs(
   opts: RequestOptions,
-  instanceTimeout: number | false | undefined,
+  instanceTimeout: number | false | TimeoutOptions | undefined,
   instanceCredentials: 'include' | 'omit' | 'same-origin' | undefined,
 ): {url: string; init: FetchInit} {
   let url = opts.url
@@ -324,7 +358,7 @@ function buildFetchArgs(
 
   // Signal — build the final abort signal
   let signal: AbortSignal | undefined = opts.signal
-  if (timeoutValue) {
+  if (typeof timeoutValue === 'number' && timeoutValue > 0) {
     const timeoutSignal = AbortSignal.timeout(timeoutValue)
     if (signal) {
       signal = AbortSignal.any([signal, timeoutSignal])

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -48,8 +48,8 @@ export class HttpError extends Error {
  * An error thrown when a request exceeds a configured timeout phase.
  *
  * Currently only produced for the `headers` phase (time-to-response-headers,
- * see {@link TimeoutOptions.headers}). Total-deadline timeouts reject with the
- * platform's `TimeoutError` DOMException, which shares the same `name` —
+ * see {@link TimeoutOptions.headers}). Total-deadline timeouts reject with a
+ * `TimeoutError` DOMException, which shares the same `name` —
  * `err.name === 'TimeoutError'` catches both.
  *
  * The `code` is the string `'ETIMEDOUT'`, which the default `retry()`

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -43,3 +43,42 @@ export class HttpError extends Error {
     this.response = opts.response
   }
 }
+
+/**
+ * An error thrown when a request exceeds a configured timeout phase.
+ *
+ * Currently only produced for the `headers` phase (time-to-response-headers,
+ * see {@link TimeoutOptions.headers}). Total-deadline timeouts reject with the
+ * platform's `TimeoutError` DOMException, which shares the same `name` —
+ * `err.name === 'TimeoutError'` catches both.
+ *
+ * The `code` is the string `'ETIMEDOUT'`, which the default `retry()`
+ * middleware treats as retryable for GET/HEAD requests.
+ *
+ * @public
+ */
+export class TimeoutError extends Error {
+  /** The URL that was requested. */
+  declare url: string
+  /** The HTTP method used (e.g. `"GET"`, `"POST"`). */
+  declare method: string
+  /** The configured timeout in milliseconds that was exceeded. */
+  declare timeoutMs: number
+  /** Which timeout phase was exceeded. */
+  declare phase: 'headers'
+  /** Node-style error code, recognized by the default `retry()` predicate. */
+  declare code: 'ETIMEDOUT'
+
+  constructor(opts: {url: string; method: string; timeoutMs: number; phase: 'headers'}) {
+    const url = opts.url.length > 400 ? opts.url.slice(0, 399) + '…' : opts.url
+    super(
+      `Request timed out after ${opts.timeoutMs}ms waiting for response headers: ${opts.method} ${url}`,
+    )
+    this.name = 'TimeoutError'
+    this.url = opts.url
+    this.method = opts.method
+    this.timeoutMs = opts.timeoutMs
+    this.phase = opts.phase
+    this.code = 'ETIMEDOUT'
+  }
+}

--- a/src/middleware/retry.ts
+++ b/src/middleware/retry.ts
@@ -127,6 +127,16 @@ function isRetryableError(error: unknown): boolean {
   const code = getErrorCode(error) ?? getErrorCode(error.cause)
   if (code) return RETRYABLE_CODES.has(code)
 
+  // Total-deadline timeouts and user aborts surface as the platform's
+  // 'TimeoutError'/'AbortError' DOMException, which has no string code.
+  // Checked before the `retryable` flag below because workerd tags its
+  // timeout DOMException with `retryable: true`. (get-it's own headers-phase
+  // TimeoutError is retryable, but it carries `code: 'ETIMEDOUT'` and is
+  // handled by the code check above.)
+  if (error.name === 'TimeoutError' || error.name === 'AbortError') {
+    return false
+  }
+
   // Cloudflare Workers (workerd) tags network failures with a `retryable`
   // flag instead of an error code.
   if ('retryable' in error && typeof error.retryable === 'boolean') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,31 @@ export type FetchFunction = (input: string, init?: FetchInit) => Promise<FetchRe
 // ---------------------------------------------------------------------------
 
 /**
+ * Structured timeout configuration. See also the shorthand forms:
+ * a plain `number` is equivalent to `{total: number}`, `false` to
+ * `{total: false}`.
+ *
+ * @public
+ */
+export interface TimeoutOptions {
+  /**
+   * Total deadline in milliseconds, from request start through body download.
+   * In stream mode the deadline continues to govern the body stream — use
+   * `total: false` for long-running downloads. `false` or `0` disables.
+   * Defaults to 120 000 when omitted.
+   */
+  total?: number | false
+  /**
+   * Maximum time in milliseconds to receive response headers, per fetch
+   * attempt — each `retry()` attempt gets a fresh timer. Covers connection
+   * setup, TLS, request-body upload, and server think time, but not body
+   * download. Fires a {@link TimeoutError}. `false` or `0` disables.
+   * Disabled when omitted.
+   */
+  headers?: number | false
+}
+
+/**
  * Configuration options for `createRequester`.
  *
  * @public
@@ -123,8 +148,12 @@ export interface RequesterOptions {
   headers?: FetchHeaders
   /** When `true` (default), throws {@link HttpError} for 4xx/5xx responses. */
   httpErrors?: boolean
-  /** Default request timeout in milliseconds. Set to `false` to disable. Defaults to 120 000 ms. */
-  timeout?: number | false
+  /**
+   * Default request timeout: total milliseconds, `false` to disable, or a
+   * structured {@link TimeoutOptions} (`{total, headers}`). Defaults to a
+   * 120 000 ms total.
+   */
+  timeout?: number | false | TimeoutOptions
   /** Custom fetch implementation. In Node.js, defaults to an undici-backed fetch. */
   fetch?: FetchFunction
   /** Credentials mode forwarded to fetch (browser-only). */
@@ -157,8 +186,11 @@ export interface RequestOptions {
   signal?: AbortSignal
   /** Override the instance-level `httpErrors` setting for this request. */
   httpErrors?: boolean
-  /** Override the instance-level `timeout` for this request. */
-  timeout?: number | false
+  /**
+   * Override the instance-level `timeout` for this request. Replaces the
+   * instance value wholesale — fields are not merged.
+   */
+  timeout?: number | false | TimeoutOptions
   /** Override the instance-level `fetch` for this request. */
   fetch?: FetchFunction
   /** Credentials mode forwarded to fetch (browser-only). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface TimeoutOptions {
    * In stream mode the deadline continues to govern the body stream — use
    * `total: false` for long-running downloads. `false` or `0` disables.
    * Defaults to 120 000 when omitted.
+   * Applies per fetch attempt - with the retry() middleware, each attempt gets a fresh deadline.
    */
   total?: number | false
   /**
@@ -149,7 +150,7 @@ export interface RequesterOptions {
   /** When `true` (default), throws {@link HttpError} for 4xx/5xx responses. */
   httpErrors?: boolean
   /**
-   * Default request timeout: total milliseconds, `false` to disable, or a
+   * Default request timeout: total milliseconds, `false` or `0` to disable, or a
    * structured {@link TimeoutOptions} (`{total, headers}`). Defaults to a
    * 120 000 ms total.
    */

--- a/test/helpers/server.ts
+++ b/test/helpers/server.ts
@@ -208,6 +208,16 @@ function getResponseHandler(proto = 'http') {
         req.on('close', () => clearTimeout(delayTimer))
         break
       }
+      case '/req-test/slow-body': {
+        res.writeHead(200, {'Content-Type': 'text/plain'})
+        res.write('partial…')
+        const slowBodyTimer = setTimeout(
+          () => res.end('done'),
+          Number(parts.searchParams.get('delay') || 1000),
+        )
+        req.on('close', () => clearTimeout(slowBodyTimer))
+        break
+      }
       case '/req-test/empty':
         res.writeHead(200, {'Content-Type': 'text/plain'})
         res.end()

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -289,6 +289,19 @@ describe('retry middleware', {timeout: 15000}, () => {
       expect(isRetryableRequest(err, 0, getOpts)).toBe(true)
     })
 
+    it('does not retry platform timeout/abort errors, even when flagged retryable', () => {
+      // workerd tags its AbortSignal.timeout() DOMException with `retryable: true`
+      const timeoutErr = Object.assign(new Error('The operation was aborted due to timeout'), {
+        retryable: true,
+      })
+      timeoutErr.name = 'TimeoutError'
+      expect(isRetryableRequest(timeoutErr, 0, getOpts)).toBe(false)
+
+      const abortErr = new Error('The operation was aborted')
+      abortErr.name = 'AbortError'
+      expect(isRetryableRequest(abortErr, 0, getOpts)).toBe(false)
+    })
+
     it('retries error flagged as retryable (Cloudflare Workers network error)', () => {
       const err = Object.assign(new Error('Network connection lost.'), {
         retryable: true,

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,4 +1,4 @@
-import {createRequester, type RequestOptions} from 'get-it'
+import {createRequester, type FetchFunction, type RequestOptions, TimeoutError} from 'get-it'
 import {retry} from 'get-it/middleware'
 import {describe, expect, it} from 'vitest'
 
@@ -212,6 +212,38 @@ describe('retry middleware', {timeout: 15000}, () => {
     await expect(
       request({url: `/fail?uuid=${Math.random()}&n=2`, method: 'post', body: 'x'}),
     ).rejects.toThrow()
+    expect(attempts).toBe(1)
+  })
+
+  it('retries headers timeouts with a fresh timer per attempt', async () => {
+    let attempts = 0
+    const neverRespond: FetchFunction = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        attempts++
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {once: true})
+      })
+    const request = createRequester({
+      fetch: neverRespond,
+      timeout: {headers: 50, total: false},
+      middleware: [retry({maxRetries: 2, retryDelay: () => 10})],
+    })
+    await expect(request('http://localhost:9999/never')).rejects.toBeInstanceOf(TimeoutError)
+    expect(attempts).toBe(3)
+  })
+
+  it('does not retry total-deadline timeouts', async () => {
+    let attempts = 0
+    const neverRespond: FetchFunction = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        attempts++
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {once: true})
+      })
+    const request = createRequester({
+      fetch: neverRespond,
+      timeout: {total: 50},
+      middleware: [retry({maxRetries: 2, retryDelay: () => 10})],
+    })
+    await expect(request('http://localhost:9999/never')).rejects.toThrow()
     expect(attempts).toBe(1)
   })
 

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,0 +1,32 @@
+import {TimeoutError} from 'get-it'
+import {describe, expect, it} from 'vitest'
+
+describe('TimeoutError', () => {
+  it('carries url, method, timeoutMs, phase, and a retryable string code', () => {
+    const err = new TimeoutError({
+      url: 'http://localhost:9980/req-test/delay',
+      method: 'GET',
+      timeoutMs: 15000,
+      phase: 'headers',
+    })
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(TimeoutError)
+    expect(err.name).toBe('TimeoutError')
+    expect(err.code).toBe('ETIMEDOUT')
+    expect(err.phase).toBe('headers')
+    expect(err.url).toBe('http://localhost:9980/req-test/delay')
+    expect(err.method).toBe('GET')
+    expect(err.timeoutMs).toBe(15000)
+    expect(err.message).toBe(
+      'Request timed out after 15000ms waiting for response headers: GET http://localhost:9980/req-test/delay',
+    )
+  })
+
+  it('truncates very long URLs in the message but keeps the full url property', () => {
+    const longUrl = `http://localhost/?q=${'x'.repeat(500)}`
+    const err = new TimeoutError({url: longUrl, method: 'GET', timeoutMs: 100, phase: 'headers'})
+    expect(err.url).toBe(longUrl)
+    expect(err.message.length).toBeLessThan(500)
+    expect(err.message).toContain('…')
+  })
+})

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,4 +1,4 @@
-import {TimeoutError} from 'get-it'
+import {createRequester, TimeoutError} from 'get-it'
 import {describe, expect, it} from 'vitest'
 import {resolveTimeout} from '../src/createRequester'
 
@@ -69,5 +69,53 @@ describe('resolveTimeout', () => {
       totalMs: undefined,
       headersMs: undefined,
     })
+  })
+})
+
+const baseUrl = 'http://localhost:9980/req-test'
+
+describe('structured timeout behavior', () => {
+  // happy-dom's fetch does not properly support AbortController on network requests
+  it.skipIf('happyDOM' in globalThis)(
+    'headers timeout fires with a TimeoutError when headers are delayed',
+    async () => {
+      const request = createRequester({base: baseUrl, timeout: {headers: 250}})
+      const err = await request('/delay?delay=5000').then(
+        () => null,
+        (reason: unknown) => reason,
+      )
+      expect(err).toBeInstanceOf(TimeoutError)
+      if (!(err instanceof TimeoutError)) throw new Error('expected TimeoutError')
+      expect(err.phase).toBe('headers')
+      expect(err.code).toBe('ETIMEDOUT')
+      expect(err.timeoutMs).toBe(250)
+      expect(err.method).toBe('GET')
+      expect(err.url).toContain('/delay')
+    },
+  )
+
+  it.skipIf('happyDOM' in globalThis)('object form {total: n} behaves like plain number', async () => {
+    const request = createRequester({base: baseUrl, timeout: {total: 200}})
+    await expect(request('/delay?delay=2000')).rejects.toThrow()
+  })
+
+  it('object form {total: false} disables the total deadline', async () => {
+    const request = createRequester({base: baseUrl, timeout: {total: false}})
+    const res = await request('/delay?delay=200')
+    expect(res.status).toBe(200)
+  })
+
+  it.skipIf('happyDOM' in globalThis)(
+    'per-request object timeout replaces instance value wholesale',
+    async () => {
+      const request = createRequester({base: baseUrl, timeout: {total: false}})
+      await expect(request({url: '/delay?delay=2000', timeout: {total: 200}})).rejects.toThrow()
+    },
+  )
+
+  it('headers timeout does not fire when the response is fast', async () => {
+    const request = createRequester({base: baseUrl, timeout: {headers: 5000}})
+    const res = await request('/plain-text')
+    expect(res.text()).toBe('Just some plain text for you to consume')
   })
 })

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -123,8 +123,11 @@ describe('structured timeout behavior', () => {
   })
 
   it('headers timeout does not fire once headers have arrived, even with a slow body', async () => {
-    const request = createRequester({base: baseUrl, timeout: {headers: 250, total: false}})
-    const res = await request('/slow-body?delay=1000')
+    // Body delay must exceed the headers timeout so an uncleared timer would
+    // still fire; the timeout is generous so headers reliably arrive within
+    // it even on a loaded CI machine.
+    const request = createRequester({base: baseUrl, timeout: {headers: 1000, total: false}})
+    const res = await request('/slow-body?delay=2000')
     expect(res.text()).toBe('partial…done')
   })
 
@@ -134,8 +137,8 @@ describe('structured timeout behavior', () => {
   })
 
   it('{headers, total: false} lets a slow stream complete', async () => {
-    const request = createRequester({base: baseUrl, timeout: {headers: 250, total: false}})
-    const res = await request({url: '/slow-body?delay=1000', as: 'stream'})
+    const request = createRequester({base: baseUrl, timeout: {headers: 1000, total: false}})
+    const res = await request({url: '/slow-body?delay=2000', as: 'stream'})
     expect(res.status).toBe(200)
     const chunks: Uint8Array[] = []
     const reader = res.body.getReader()

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,5 +1,6 @@
 import {TimeoutError} from 'get-it'
 import {describe, expect, it} from 'vitest'
+import {resolveTimeout} from '../src/createRequester'
 
 describe('TimeoutError', () => {
   it('carries url, method, timeoutMs, phase, and a retryable string code', () => {
@@ -28,5 +29,45 @@ describe('TimeoutError', () => {
     expect(err.url).toBe(longUrl)
     expect(err.message.length).toBeLessThan(500)
     expect(err.message).toContain('…')
+  })
+})
+
+describe('resolveTimeout', () => {
+  it('treats a plain number as total', () => {
+    expect(resolveTimeout(5000)).toEqual({totalMs: 5000, headersMs: undefined})
+  })
+
+  it('false and 0 disable total', () => {
+    expect(resolveTimeout(false)).toEqual({totalMs: undefined, headersMs: undefined})
+    expect(resolveTimeout(0)).toEqual({totalMs: undefined, headersMs: undefined})
+  })
+
+  it('defaults total to 120s when unset', () => {
+    expect(resolveTimeout(undefined)).toEqual({totalMs: 120_000, headersMs: undefined})
+    expect(resolveTimeout({headers: 15_000})).toEqual({totalMs: 120_000, headersMs: 15_000})
+  })
+
+  it('object form: explicit fields win, falsy disables per field', () => {
+    expect(resolveTimeout({total: 30_000, headers: 5000})).toEqual({
+      totalMs: 30_000,
+      headersMs: 5000,
+    })
+    expect(resolveTimeout({total: false, headers: 5000})).toEqual({
+      totalMs: undefined,
+      headersMs: 5000,
+    })
+    expect(resolveTimeout({total: 0})).toEqual({totalMs: undefined, headersMs: undefined})
+    expect(resolveTimeout({total: 30_000, headers: 0})).toEqual({
+      totalMs: 30_000,
+      headersMs: undefined,
+    })
+  })
+
+  it('negative values disable a phase', () => {
+    expect(resolveTimeout(-1)).toEqual({totalMs: undefined, headersMs: undefined})
+    expect(resolveTimeout({total: -1, headers: -1})).toEqual({
+      totalMs: undefined,
+      headersMs: undefined,
+    })
   })
 })

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -94,10 +94,13 @@ describe('structured timeout behavior', () => {
     },
   )
 
-  it.skipIf('happyDOM' in globalThis)('object form {total: n} behaves like plain number', async () => {
-    const request = createRequester({base: baseUrl, timeout: {total: 200}})
-    await expect(request('/delay?delay=2000')).rejects.toThrow()
-  })
+  it.skipIf('happyDOM' in globalThis)(
+    'object form {total: n} behaves like plain number',
+    async () => {
+      const request = createRequester({base: baseUrl, timeout: {total: 200}})
+      await expect(request('/delay?delay=2000')).rejects.toThrow()
+    },
+  )
 
   it('object form {total: false} disables the total deadline', async () => {
     const request = createRequester({base: baseUrl, timeout: {total: false}})

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -118,4 +118,37 @@ describe('structured timeout behavior', () => {
     const res = await request('/plain-text')
     expect(res.text()).toBe('Just some plain text for you to consume')
   })
+
+  it('headers timeout does not fire once headers have arrived, even with a slow body', async () => {
+    const request = createRequester({base: baseUrl, timeout: {headers: 250, total: false}})
+    const res = await request('/slow-body?delay=1000')
+    expect(res.text()).toBe('partial…done')
+  })
+
+  it.skipIf('happyDOM' in globalThis)('total covers slow bodies in buffered mode', async () => {
+    const request = createRequester({base: baseUrl, timeout: {total: 250}})
+    await expect(request('/slow-body?delay=5000')).rejects.toThrow()
+  })
+
+  it('{headers, total: false} lets a slow stream complete', async () => {
+    const request = createRequester({base: baseUrl, timeout: {headers: 250, total: false}})
+    const res = await request({url: '/slow-body?delay=1000', as: 'stream'})
+    expect(res.status).toBe(200)
+    const chunks: Uint8Array[] = []
+    const reader = res.body.getReader()
+    for (;;) {
+      const {done, value} = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+    const text = new TextDecoder().decode(
+      chunks.reduce((acc, chunk) => {
+        const merged = new Uint8Array(acc.length + chunk.length)
+        merged.set(acc)
+        merged.set(chunk, acc.length)
+        return merged
+      }, new Uint8Array(0)),
+    )
+    expect(text).toBe('partial…done')
+  })
 })


### PR DESCRIPTION
## Motivation

v9 replaced v8's `timeout: {connect, socket}` with a single total-deadline timeout. That left streaming consumers unable to use any finite timeout (the abort signal stays attached to the response body and would kill a slow-but-healthy download mid-stream), and made timeouts non-retryable by the default `retry()` predicate. The sanity-io/cli v9 migration (sanity-io/cli#1534) had to hand-roll ~90 lines of timeout middleware with a hard ordering requirement relative to `retry()` to work around this.

## What's new

- `timeout` now also accepts `{total?, headers?}` alongside the existing `number | false` forms:
  - `total`: the existing deadline (default 120s, unchanged semantics; plain `number`/`false` remain exact shorthands)
  - `headers`: max time to receive response headers, per fetch attempt; does not cover body download
- New exported `TimeoutError` (`name: 'TimeoutError'`, `code: 'ETIMEDOUT'`, `phase: 'headers'`): headers timeouts are retryable by the default `retry()` middleware on GET/HEAD, with zero changes to retry.ts
- The headers timer lives in the core fetch layer, inside the wrapping-middleware chain, so each `retry()` attempt gets a fresh timer with no middleware ordering requirements
- Streaming recipe replaces the hand-rolled middleware: `createRequester({middleware: [retry()], timeout: {headers: 15_000, total: false}})`

## Notes

- Object form keeps the 120s total default unless `total: false` is set explicitly, so reaching for `{headers}` on ordinary requests does not silently drop the safety net
- Per-request `timeout` replaces the instance value wholesale (existing behavior, now documented)
- An idle/stall timeout (v8's `socket`) was deliberately left out: get-it never reads bodies chunk-by-chunk, so it would require a new body-handling path in every mode. Design doc: `docs/superpowers/specs/2026-07-17-structured-timeouts-design.md`

## Testing

- New `test/timeout.test.ts`: TimeoutError contract, `resolveTimeout` normalization, and behavioral tests against the real test server, including a new `/slow-body` route pinning the phase separation (headers timer stops at headers; total covers slow bodies; `{headers, total: false}` lets a slow stream complete)
- `test/retry.test.ts`: headers timeouts retried with a fresh timer per attempt; total timeouts intentionally not retried
- Full suite 359/359 across all runtime pools, plus format, lint, and typecheck clean