### PR TITLE
feat(mock): streaming response bodies via streamBody()

### DIFF
--- a/.changeset/mock-streaming-responses.md
+++ b/.changeset/mock-streaming-responses.md
@@ -1,0 +1,5 @@
+---
+'get-it': minor
+---
+
+`get-it/mock` can now stream response bodies: `streamBody()` declares chunked delivery with `streamDelay()` pauses, `streamStall()` for bodies that never complete, and `streamError()` for mid-download connection cuts. The handle records consumer cancellations (`cancelCount`, `lastCancelReason`), assertable via the new `toHaveBeenCancelled()` matcher in `get-it/vitest`. Aborting the request signal errors the body with the abort reason, matching real fetch behavior.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,40 @@ mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 100})
 
 The request is treated as sent immediately; the response resolves after `delay` ms. If the request is aborted before the delay elapses - via an `AbortController` signal or a get-it `timeout` - it rejects with the signal's reason and the pending timer is cleared.
 
+### Streaming response bodies
+
+`streamBody()` declares a body delivered in chunks, with optional pauses, a
+stall, or a mid-download error. A fresh stream is built per consumption, so it
+works with `respondPersist`. `delay` still controls time-to-headers; the
+script controls the body after that.
+
+```ts
+import {createMockFetch, streamBody, streamDelay, streamStall} from 'get-it/mock'
+
+const mock = createMockFetch()
+mock.on('GET', '/backup').respond({
+  status: 200,
+  body: streamBody('partial', streamDelay(1000), 'done'),
+})
+
+// A download that stalls forever after the first chunk:
+const stalled = streamBody('partial', streamStall())
+mock.on('GET', '/stuck').respond({body: stalled})
+
+// ...after the consumer cancels the body (e.g. its read timeout fired):
+expect(stalled).toHaveBeenCancelled() // matcher from 'get-it/vitest'
+```
+
+- `streamDelay(ms)` pauses between chunks; `streamStall()` never closes the
+  body (ends only via consumer cancel or signal abort); `streamError(err)`
+  errors the stream mid-download.
+- Aborting the request signal errors the body with the abort reason, matching
+  real fetch behavior.
+- Buffered reads (no `as`, or `text()`/`arrayBuffer()`) drain the script with
+  the same timing, so total-deadline timeout behavior is testable too.
+- The `streamBody()` return value is the observability handle: `cancelCount`
+  and `lastCancelReason`, or assert with `expect(body).toHaveBeenCancelled()`.
+
 ### Scoped mocks
 
 When your code talks to multiple hosts, use `mock.scope()` to assert the right requests go to the right place:

--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ expect(mock).toHaveReceivedRequest('POST', '/api/docs', {
 expect(mock).toHaveReceivedRequestTimes('GET', '/api/docs', 2)
 expect(mock).toHaveConsumedAllMocks()
 
+// Assert a streamBody() response body was cancelled by the consumer
+expect(scriptedBody).toHaveBeenCancelled()
+
 // Assert on individual recorded requests
 const req = mock.getRequests()[0]
 expect(req).toHaveHeader('authorization', 'Bearer token123')

--- a/src/_exports/mock.ts
+++ b/src/_exports/mock.ts
@@ -18,3 +18,5 @@ export {
   queryContaining,
   stringMatching,
 } from '../mock/matchers'
+export type {StreamDirective, StreamPart} from '../mock/streamBody'
+export {StreamBody, streamBody, streamDelay, streamError, streamStall} from '../mock/streamBody'

--- a/src/_exports/vitest.ts
+++ b/src/_exports/vitest.ts
@@ -19,5 +19,6 @@ declare module 'vitest' {
     toHaveQuery(expected: unknown): void
     toHaveMethod(expected: string): void
     toHaveUrl(expected: string): void
+    toHaveBeenCancelled(): void
   }
 }

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -13,6 +13,7 @@ import type {MockDescription} from './errors'
 import {MockFetchError} from './errors'
 import type {AsymmetricMatcher} from './matchers'
 import {deepMatch, isAsymmetricMatcher, isRecord} from './matchers'
+import {delayWithAbort} from './streamBody'
 import {matchUrl, parseUrl} from './urlMatch'
 
 // ---------------------------------------------------------------------------
@@ -257,30 +258,6 @@ function expectedBodyOf(handler: InternalHandler): unknown {
  */
 function resolveError(error: Error | (() => Error)): Error {
   return typeof error === 'function' ? error() : error
-}
-
-/**
- * Wait `ms` milliseconds, rejecting with the signal's reason if it aborts
- * first. Clears the timer on abort so it cannot resolve a request that should
- * already have rejected.
- * @internal
- */
-function delayWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(signal.reason)
-      return
-    }
-    const onAbort = () => {
-      clearTimeout(timer)
-      reject(signal?.reason)
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    signal?.addEventListener('abort', onAbort, {once: true})
-  })
 }
 
 /**

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -13,7 +13,7 @@ import type {MockDescription} from './errors'
 import {MockFetchError} from './errors'
 import type {AsymmetricMatcher} from './matchers'
 import {deepMatch, isAsymmetricMatcher, isRecord} from './matchers'
-import {delayWithAbort} from './streamBody'
+import {delayWithAbort, drainScript, StreamBody, streamFromScript} from './streamBody'
 import {matchUrl, parseUrl} from './urlMatch'
 
 // ---------------------------------------------------------------------------
@@ -264,11 +264,41 @@ function resolveError(error: Error | (() => Error)): Error {
  * Build a FetchResponse-compatible object from a MockResponseDef.
  * @internal
  */
-function buildFetchResponse(def: MockResponseDef, url: string): FetchResponse {
+function buildFetchResponse(
+  def: MockResponseDef,
+  url: string,
+  signal: AbortSignal | undefined,
+): FetchResponse {
   const status = def.status ?? 200
   const ok = status >= 200 && status < 300
   const statusText = def.statusText ?? statusTextForCode(status)
   const responseHeaders = new Headers(def.headers)
+
+  if (def.body instanceof StreamBody) {
+    const scripted = def.body
+    return {
+      ok,
+      status,
+      statusText,
+      headers: responseHeaders,
+      url,
+      redirected: false,
+      body: streamFromScript(scripted, signal),
+      async text(): Promise<string> {
+        return new TextDecoder().decode(await drainScript(scripted, signal))
+      },
+      async arrayBuffer(): Promise<ArrayBuffer> {
+        const bytes = await drainScript(scripted, signal)
+        // `drainScript`'s return type is `Uint8Array` (default `ArrayBufferLike`
+        // type param), so `.buffer` alone would be `ArrayBuffer | SharedArrayBuffer`.
+        // Copying into a fresh `Uint8Array(length)` gets a concretely
+        // `ArrayBuffer`-backed buffer, matching `FetchResponse.arrayBuffer()`.
+        const copy = new Uint8Array(bytes.byteLength)
+        copy.set(bytes)
+        return copy.buffer
+      },
+    }
+  }
 
   let bodyString: string
   if (def.body === undefined || def.body === null) {
@@ -714,7 +744,7 @@ export function createMockFetch(): MockFetch {
       if (def.delay !== undefined && def.delay > 0) {
         await delayWithAbort(def.delay, init?.signal)
       }
-      return buildFetchResponse(def, input)
+      return buildFetchResponse(def, input, init?.signal)
     }
 
     // No match found — build error

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -276,6 +276,13 @@ function buildFetchResponse(
 
   if (def.body instanceof StreamBody) {
     const scripted = def.body
+    // Constructed lazily (and memoized) rather than eagerly: `body` is only
+    // needed for `as: 'stream'` consumption, but buffered reads (text()/
+    // arrayBuffer()) drain the script independently via `drainScript()`.
+    // Building it eagerly would register its abort listener on `signal` even
+    // for buffered requests, and with `respondPersist` sharing one signal
+    // across many requests, those listeners would accumulate.
+    let lazyBody: ReadableStream<Uint8Array> | undefined
     return {
       ok,
       status,
@@ -283,7 +290,10 @@ function buildFetchResponse(
       headers: responseHeaders,
       url,
       redirected: false,
-      body: streamFromScript(scripted, signal),
+      get body(): ReadableStream<Uint8Array> {
+        lazyBody ??= streamFromScript(scripted, signal)
+        return lazyBody
+      },
       async text(): Promise<string> {
         return new TextDecoder().decode(await drainScript(scripted, signal))
       },

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -38,7 +38,11 @@ export class StreamBody {
   /** Use {@link streamBody} instead of constructing directly. @internal */
   constructor(parts: ReadonlyArray<StreamPart>) {
     parts.forEach(assertValidPart)
-    this.script = parts
+    // Copy Uint8Array parts to protect against external mutations
+    const copiedParts = parts.map(part =>
+      part instanceof Uint8Array ? part.slice() : part,
+    )
+    this.script = copiedParts
   }
 }
 
@@ -126,4 +130,126 @@ export function delayWithAbort(ms: number, signal: AbortSignal | undefined): Pro
     }, ms)
     signal?.addEventListener('abort', onAbort, {once: true})
   })
+}
+
+// ---------------------------------------------------------------------------
+// Interpreter
+// ---------------------------------------------------------------------------
+
+const encoder = new TextEncoder()
+
+/**
+ * Returns a promise that rejects with the signal's reason when it aborts,
+ * and never settles otherwise — the waiting state of a stalled body.
+ * @internal
+ */
+function stallUntilAborted(signal: AbortSignal | undefined): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    if (!signal) return
+    if (signal.aborted) {
+      reject(signal.reason)
+      return
+    }
+    signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+  })
+}
+
+/**
+ * Build a fresh `ReadableStream` that plays back a {@link StreamBody} script.
+ * Each call produces an independent stream (persist-safe). Aborting `signal`
+ * errors the stream with the signal's reason, mirroring real fetch behavior;
+ * consumer cancellation is recorded on the handle.
+ * @internal
+ */
+export function streamFromScript(
+  body: StreamBody,
+  signal: AbortSignal | undefined,
+): ReadableStream<Uint8Array> {
+  const parts = body.script
+  let index = 0
+  let onAbort: (() => void) | undefined
+
+  const removeAbortListener = () => {
+    if (onAbort) {
+      signal?.removeEventListener('abort', onAbort)
+      onAbort = undefined
+    }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (!signal) return
+      if (signal.aborted) {
+        controller.error(signal.reason)
+        return
+      }
+      // Erroring an already-errored/closed stream is a spec-level no-op, so
+      // this listener is safe even when pull() also rejects on the same abort.
+      onAbort = () => {
+        removeAbortListener()
+        controller.error(signal.reason)
+      }
+      signal.addEventListener('abort', onAbort, {once: true})
+    },
+    async pull(controller) {
+      while (index < parts.length) {
+        const part = parts[index++]
+        if (typeof part === 'string') {
+          controller.enqueue(encoder.encode(part))
+          return
+        }
+        if (part instanceof Uint8Array) {
+          controller.enqueue(part.slice())
+          return
+        }
+        if (part.kind === 'delay') {
+          await delayWithAbort(part.ms, signal)
+          continue
+        }
+        if (part.kind === 'stall') {
+          await stallUntilAborted(signal)
+          return
+        }
+        removeAbortListener()
+        controller.error(part.error)
+        return
+      }
+      removeAbortListener()
+      controller.close()
+    },
+    cancel(reason) {
+      removeAbortListener()
+      body.cancelCount++
+      body.lastCancelReason = reason
+    },
+  })
+}
+
+/**
+ * Independently walk a {@link StreamBody} script to completion, honoring
+ * delays, and return the concatenated bytes. Used by the mock response's
+ * `text()`/`arrayBuffer()` accessors so buffered reads stay faithful to the
+ * script's timing.
+ * @internal
+ */
+export async function drainScript(
+  body: StreamBody,
+  signal: AbortSignal | undefined,
+): Promise<Uint8Array> {
+  const reader = streamFromScript(body, signal).getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (;;) {
+    const {done, value} = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.byteLength
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
 }

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A directive controlling timing or termination inside a {@link streamBody}
+ * script. Create via {@link streamDelay}, {@link streamStall}, or
+ * {@link streamError}.
+ * @public
+ */
+export type StreamDirective =
+  | {kind: 'delay'; ms: number}
+  | {kind: 'stall'}
+  | {kind: 'error'; error: Error}
+
+/**
+ * One part of a {@link streamBody} script: a body chunk (string is UTF-8
+ * encoded, `Uint8Array` passes through as bytes) or a {@link StreamDirective}.
+ * @public
+ */
+export type StreamPart = string | Uint8Array | StreamDirective
+
+/**
+ * Marker object recognized in `MockResponseDef.body`, produced by
+ * {@link streamBody}. Also serves as the observability handle: a fresh
+ * stream is built from the script for every consumption, and consumer
+ * cancellations are aggregated on this object.
+ * @public
+ */
+export class StreamBody {
+  /** Number of times a consumer cancelled a stream produced from this script. */
+  cancelCount = 0
+  /** The reason passed to the most recent cancel, if any. */
+  lastCancelReason: unknown = undefined
+  /** The validated script. @internal */
+  readonly script: ReadonlyArray<StreamPart>
+
+  /** Use {@link streamBody} instead of constructing directly. @internal */
+  constructor(parts: ReadonlyArray<StreamPart>) {
+    parts.forEach(assertValidPart)
+    this.script = parts
+  }
+}
+
+function assertValidPart(part: StreamPart, index: number, parts: ReadonlyArray<StreamPart>): void {
+  if (typeof part === 'string' || part instanceof Uint8Array) return
+  if (part.kind === 'delay') {
+    if (!(part.ms >= 0)) {
+      throw new TypeError(`streamBody(): invalid delay at index ${index}: ${part.ms}`)
+    }
+    return
+  }
+  if (index !== parts.length - 1) {
+    throw new TypeError(`streamBody(): ${part.kind}() must be the last part (found at index ${index})`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Declare a streaming mock response body: chunks delivered in order,
+ * interleaved with timing/termination directives. Pass the result as
+ * `MockResponseDef.body`. Validates the script eagerly.
+ *
+ * @example
+ * ```ts
+ * const body = streamBody('partial', streamDelay(1000), 'done')
+ * mock.on('GET', '/backup').respond({status: 200, body})
+ * ```
+ *
+ * @public
+ */
+export function streamBody(...parts: StreamPart[]): StreamBody {
+  return new StreamBody(parts)
+}
+
+/** Pause `ms` milliseconds before delivering the next part. @public */
+export function streamDelay(ms: number): StreamDirective {
+  return {kind: 'delay', ms}
+}
+
+/**
+ * Terminal directive: after the preceding chunks, the body never closes.
+ * The stream ends only when the consumer cancels it or the request's
+ * abort signal fires.
+ * @public
+ */
+export function streamStall(): StreamDirective {
+  return {kind: 'stall'}
+}
+
+/**
+ * Terminal directive: after the preceding chunks, the body stream errors
+ * with `error`, simulating a connection cut mid-download.
+ * @public
+ */
+export function streamError(error: Error): StreamDirective {
+  return {kind: 'error', error}
+}
+
+// ---------------------------------------------------------------------------
+// Timing primitive (shared with createMockFetch's response-level delay)
+// ---------------------------------------------------------------------------
+
+/**
+ * Wait `ms` milliseconds, rejecting with the signal's reason if it aborts
+ * first. Clears the timer on abort so it cannot resolve a request that should
+ * already have rejected.
+ * @internal
+ */
+export function delayWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason)
+      return
+    }
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal?.reason)
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', onAbort, {once: true})
+  })
+}

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -38,8 +38,14 @@ export class StreamBody {
   /** Use {@link streamBody} instead of constructing directly. @internal */
   constructor(parts: ReadonlyArray<StreamPart>) {
     parts.forEach(assertValidPart)
-    // Copy Uint8Array parts to protect against external mutations
-    const copiedParts = parts.map((part) => (part instanceof Uint8Array ? part.slice() : part))
+    // Copy Uint8Array parts to protect against external mutations. `new
+    // Uint8Array(part)` (rather than `part.slice()`) also protects against
+    // `Buffer` inputs: `Buffer` (a `Uint8Array` subclass) overrides `slice()`
+    // to return a view sharing the same backing memory, which would leave
+    // the snapshot unprotected against later mutation of the source buffer.
+    const copiedParts = parts.map((part) =>
+      part instanceof Uint8Array ? new Uint8Array(part) : part,
+    )
     this.script = copiedParts
   }
 }
@@ -169,6 +175,12 @@ export function streamFromScript(
   let index = 0
   let onAbort: (() => void) | undefined
 
+  // Internal controller so a consumer cancel() can interrupt an in-flight
+  // delayWithAbort/stallUntilAborted wait immediately, instead of leaving its
+  // timer/listener alive until the script would otherwise have continued.
+  const done = new AbortController()
+  const waitSignal = signal ? AbortSignal.any([signal, done.signal]) : done.signal
+
   const removeAbortListener = () => {
     if (onAbort) {
       signal?.removeEventListener('abort', onAbort)
@@ -183,6 +195,9 @@ export function streamFromScript(
         controller.error(signal.reason)
         return
       }
+      // Listens on the external signal directly (not `waitSignal`) so the
+      // stream always errors with the original abort reason, regardless of
+      // the internal controller used for cancel()-interruption.
       // Erroring an already-errored/closed stream is a spec-level no-op, so
       // this listener is safe even when pull() also rejects on the same abort.
       onAbort = () => {
@@ -199,15 +214,15 @@ export function streamFromScript(
           return
         }
         if (part instanceof Uint8Array) {
-          controller.enqueue(part.slice())
+          controller.enqueue(new Uint8Array(part))
           return
         }
         if (part.kind === 'delay') {
-          await delayWithAbort(part.ms, signal)
+          await delayWithAbort(part.ms, waitSignal)
           continue
         }
         if (part.kind === 'stall') {
-          await stallUntilAborted(signal)
+          await stallUntilAborted(waitSignal)
           return
         }
         removeAbortListener()
@@ -221,6 +236,9 @@ export function streamFromScript(
       removeAbortListener()
       body.cancelCount++
       body.lastCancelReason = reason
+      // Interrupts any pending delayWithAbort/stallUntilAborted wait so its
+      // timer/listener does not linger for the rest of the script's delay.
+      done.abort()
     },
   })
 }

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -39,9 +39,7 @@ export class StreamBody {
   constructor(parts: ReadonlyArray<StreamPart>) {
     parts.forEach(assertValidPart)
     // Copy Uint8Array parts to protect against external mutations
-    const copiedParts = parts.map(part =>
-      part instanceof Uint8Array ? part.slice() : part,
-    )
+    const copiedParts = parts.map((part) => (part instanceof Uint8Array ? part.slice() : part))
     this.script = copiedParts
   }
 }
@@ -55,7 +53,9 @@ function assertValidPart(part: StreamPart, index: number, parts: ReadonlyArray<S
     return
   }
   if (index !== parts.length - 1) {
-    throw new TypeError(`streamBody(): ${part.kind}() must be the last part (found at index ${index})`)
+    throw new TypeError(
+      `streamBody(): ${part.kind}() must be the last part (found at index ${index})`,
+    )
   }
 }
 

--- a/src/mock/vitestMatchers.ts
+++ b/src/mock/vitestMatchers.ts
@@ -1,6 +1,7 @@
 import type {MockFetch, MockMatchOptions, RecordedRequest} from './createMockFetch'
 import {deepMatch} from './matchers'
 import {matchUrl, parseUrl} from './urlMatch'
+import {StreamBody} from './streamBody'
 
 // ---------------------------------------------------------------------------
 // Type guards
@@ -256,6 +257,29 @@ function toHaveUrl(received: unknown, expected: string): MatcherResult {
 }
 
 // ---------------------------------------------------------------------------
+// StreamBody matchers
+// ---------------------------------------------------------------------------
+
+function toHaveBeenCancelled(received: unknown): MatcherResult {
+  if (!(received instanceof StreamBody)) {
+    return {
+      pass: false,
+      message: () => 'Expected value to be a streamBody() instance',
+    }
+  }
+
+  const pass = received.cancelCount > 0
+
+  return {
+    pass,
+    message: pass
+      ? () =>
+          `Expected stream body not to have been cancelled, but it was cancelled ${received.cancelCount} time(s) (last reason: ${String(received.lastCancelReason)})`
+      : () => 'Expected stream body to have been cancelled, but it never was',
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Exported matcher map
 // ---------------------------------------------------------------------------
 
@@ -272,4 +296,5 @@ export const mockMatchers = {
   toHaveQuery,
   toHaveMethod,
   toHaveUrl,
+  toHaveBeenCancelled,
 }

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1681,6 +1681,20 @@ describe('createMockFetch', () => {
       expect(second.text()).toBe('again')
     })
 
+    it('handles many buffered requests against a respondPersist stream body sharing one AbortController', async () => {
+      const mock = createMockFetch()
+      mock.onAny('/repeat').respondPersist({body: streamBody('x')})
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+      const controller = new AbortController()
+
+      const responses = await Promise.all(
+        Array.from({length: 15}, () => request({url: '/repeat', signal: controller.signal})),
+      )
+      for (const res of responses) {
+        expect(res.text()).toBe('x')
+      }
+    })
+
     it('supports the stall + cancel download scenario (sanity-io/cli#1534 shape)', async () => {
       const body = streamBody('partial', streamStall())
       const mock = createMockFetch()

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -12,6 +12,7 @@ import {
   queryContaining,
   stringMatching,
 } from '../../src/mock/matchers'
+import {streamBody, streamDelay, streamError, streamStall} from '../../src/mock/streamBody'
 
 describe('createMockFetch', () => {
   describe('basic matching', () => {
@@ -1615,6 +1616,139 @@ describe('createMockFetch', () => {
       expect(error).toBeInstanceOf(Error)
       if (!(error instanceof Error)) throw new Error('expected an error')
       expect(error.message).toContain('headers.x-a: expected "1", received "2"')
+    })
+  })
+
+  describe('streaming responses', () => {
+    it('streams a multi-chunk body through as: "stream"', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/backup').respond({
+        status: 200,
+        body: streamBody('hello', streamDelay(20), ' world'),
+      })
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+
+      const res = await request({url: '/backup', as: 'stream'})
+      expect(res.status).toBe(200)
+      const reader = res.body.getReader()
+      const received: string[] = []
+      const decoder = new TextDecoder()
+      for (;;) {
+        const {done, value} = await reader.read()
+        if (done) break
+        received.push(decoder.decode(value))
+      }
+      expect(received).toEqual(['hello', ' world'])
+    })
+
+    it('buffered mode drains the script honoring delays', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/slow').respond({body: streamBody('slow', streamDelay(60), ' body')})
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+
+      const start = Date.now()
+      const res = await request('/slow')
+      expect(res.text()).toBe('slow body')
+      expect(Date.now() - start).toBeGreaterThanOrEqual(50)
+    })
+
+    it('buffered mode rejects when the script errors mid-body', async () => {
+      const cut = new Error('connection cut')
+      const mock = createMockFetch()
+      mock.on('GET', '/cut').respond({body: streamBody('partial', streamError(cut))})
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+
+      await expect(request('/cut')).rejects.toBe(cut)
+    })
+
+    it('does not auto-set a content-type for stream bodies', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/raw').respond({body: streamBody('x')})
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+
+      const res = await request({url: '/raw', as: 'stream'})
+      expect(res.headers.get('content-type')).toBeNull()
+    })
+
+    it('respondPersist rebuilds an independent stream per consumption', async () => {
+      const mock = createMockFetch()
+      mock.onAny('/repeat').respondPersist({body: streamBody('again')})
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+
+      const first = await request('/repeat')
+      const second = await request('/repeat')
+      expect(first.text()).toBe('again')
+      expect(second.text()).toBe('again')
+    })
+
+    it('supports the stall + cancel download scenario (sanity-io/cli#1534 shape)', async () => {
+      const body = streamBody('partial', streamStall())
+      const mock = createMockFetch()
+      mock.on('GET', '/backup').respond({status: 200, body})
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: mock.fetch,
+        timeout: false,
+      })
+
+      const res = await request({url: '/backup', as: 'stream'})
+      const reader = res.body.getReader()
+      const first = await reader.read()
+      expect(new TextDecoder().decode(first.value)).toBe('partial')
+
+      // Consumer-side read timeout fires: cancel the body like pipeline teardown would.
+      const timeoutError = new Error('no data received for 3 minutes')
+      await reader.cancel(timeoutError)
+
+      expect(body.cancelCount).toBe(1)
+      expect(body.lastCancelReason).toBe(timeoutError)
+    })
+
+    it('composes response-level delay (time-to-headers) with a stream script', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/late').respond({
+        delay: 40,
+        body: streamBody('a', streamDelay(40), 'b'),
+      })
+      const request = createRequester({base: 'https://api.example.com', fetch: mock.fetch})
+
+      const start = Date.now()
+      const res = await request({url: '/late', as: 'stream'})
+      const headersAt = Date.now() - start
+      expect(headersAt).toBeGreaterThanOrEqual(30)
+
+      const reader = res.body.getReader()
+      const chunks: string[] = []
+      const decoder = new TextDecoder()
+      for (;;) {
+        const {done, value} = await reader.read()
+        if (done) break
+        chunks.push(decoder.decode(value))
+      }
+      expect(chunks).toEqual(['a', 'b'])
+      expect(Date.now() - start).toBeGreaterThanOrEqual(headersAt + 30)
+    })
+
+    it('errors the body when the request signal aborts mid-download', async () => {
+      const body = streamBody('partial', streamStall())
+      const mock = createMockFetch()
+      mock.on('GET', '/backup').respond({body})
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: mock.fetch,
+        timeout: false,
+      })
+
+      const controller = new AbortController()
+      const res = await request({url: '/backup', as: 'stream', signal: controller.signal})
+      const reader = res.body.getReader()
+      await reader.read()
+
+      const abortError = new Error('client gave up')
+      const pendingRead = reader.read()
+      controller.abort(abortError)
+      await expect(pendingRead).rejects.toBe(abortError)
+      expect(body.cancelCount).toBe(0)
     })
   })
 })

--- a/test/mock/streamBody.test.ts
+++ b/test/mock/streamBody.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  StreamBody,
+  streamBody,
+  streamDelay,
+  streamError,
+  streamStall,
+} from '../../src/mock/streamBody'
+
+describe('streamBody()', () => {
+  it('builds a StreamBody with the script and zeroed counters', () => {
+    const body = streamBody('hello', streamDelay(10), new Uint8Array([1, 2]), streamStall())
+    expect(body).toBeInstanceOf(StreamBody)
+    expect(body.cancelCount).toBe(0)
+    expect(body.lastCancelReason).toBeUndefined()
+    expect(body.script).toHaveLength(4)
+  })
+
+  it('allows an empty script', () => {
+    expect(streamBody().script).toHaveLength(0)
+  })
+
+  it('throws when a terminal directive is not last', () => {
+    expect(() => streamBody(streamStall(), 'late')).toThrow(
+      new TypeError('streamBody(): stall() must be the last part (found at index 0)'),
+    )
+    expect(() => streamBody('a', streamError(new Error('cut')), 'b')).toThrow(
+      new TypeError('streamBody(): error() must be the last part (found at index 1)'),
+    )
+  })
+
+  it('throws on negative or NaN delays', () => {
+    expect(() => streamBody(streamDelay(-1))).toThrow(
+      new TypeError('streamBody(): invalid delay at index 0: -1'),
+    )
+    expect(() => streamBody('a', streamDelay(NaN))).toThrow(
+      new TypeError('streamBody(): invalid delay at index 1: NaN'),
+    )
+  })
+
+  it('allows a zero delay and a terminal directive as the only part', () => {
+    expect(() => streamBody(streamDelay(0))).not.toThrow()
+    expect(() => streamBody(streamStall())).not.toThrow()
+    expect(() => streamBody(streamError(new Error('x')))).not.toThrow()
+  })
+})

--- a/test/mock/streamBody.test.ts
+++ b/test/mock/streamBody.test.ts
@@ -6,6 +6,9 @@ import {
   streamDelay,
   streamError,
   streamStall,
+  delayWithAbort,
+  drainScript,
+  streamFromScript,
 } from '../../src/mock/streamBody'
 
 describe('streamBody()', () => {
@@ -43,5 +46,147 @@ describe('streamBody()', () => {
     expect(() => streamBody(streamDelay(0))).not.toThrow()
     expect(() => streamBody(streamStall())).not.toThrow()
     expect(() => streamBody(streamError(new Error('x')))).not.toThrow()
+  })
+})
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  for (;;) {
+    const {done, value} = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  let total = 0
+  for (const c of chunks) total += c.byteLength
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    out.set(c, offset)
+    offset += c.byteLength
+  }
+  return new TextDecoder().decode(out)
+}
+
+describe('streamFromScript', () => {
+  it('delivers string and binary chunks in order, then closes', async () => {
+    const body = streamBody('hello ', new Uint8Array([119, 111, 114, 108, 100]))
+    expect(await readAll(streamFromScript(body, undefined))).toBe('hello world')
+  })
+
+  it('closes immediately for an empty script', async () => {
+    expect(await readAll(streamFromScript(streamBody(), undefined))).toBe('')
+  })
+
+  it('delivers each chunk as its own read', async () => {
+    const reader = streamFromScript(streamBody('a', 'b'), undefined).getReader()
+    const first = await reader.read()
+    expect(new TextDecoder().decode(first.value)).toBe('a')
+    const second = await reader.read()
+    expect(new TextDecoder().decode(second.value)).toBe('b')
+    expect((await reader.read()).done).toBe(true)
+  })
+
+  it('copies Uint8Array chunks so later mutation does not leak in', async () => {
+    const bytes = new Uint8Array([1, 2, 3])
+    const body = streamBody(bytes)
+    const reader = streamFromScript(body, undefined).getReader()
+    bytes[0] = 9
+    const {value} = await reader.read()
+    if (value === undefined) throw new Error('expected a chunk')
+    expect(Array.from(value)).toEqual([1, 2, 3])
+  })
+
+  it('waits for streamDelay between chunks', async () => {
+    const body = streamBody('a', streamDelay(60), 'b')
+    const start = Date.now()
+    const text = await readAll(streamFromScript(body, undefined))
+    expect(text).toBe('ab')
+    expect(Date.now() - start).toBeGreaterThanOrEqual(50)
+  })
+
+  it('errors the stream with the given error on streamError', async () => {
+    const cut = new Error('connection cut')
+    const body = streamBody('partial', streamError(cut))
+    await expect(readAll(streamFromScript(body, undefined))).rejects.toBe(cut)
+  })
+
+  it('stalls until cancelled, recording count and reason', async () => {
+    const body = streamBody('partial', streamStall())
+    const reader = streamFromScript(body, undefined).getReader()
+    const first = await reader.read()
+    expect(new TextDecoder().decode(first.value)).toBe('partial')
+
+    const pendingRead = reader.read()
+    const raceMarker = Symbol('still-pending')
+    await expect(
+      Promise.race([pendingRead, delayWithAbort(40, undefined).then(() => raceMarker)]),
+    ).resolves.toBe(raceMarker)
+
+    const reason = new Error('read timeout')
+    await reader.cancel(reason)
+    expect(body.cancelCount).toBe(1)
+    expect(body.lastCancelReason).toBe(reason)
+  })
+
+  it('errors with the signal reason when aborted mid-delay', async () => {
+    const controller = new AbortController()
+    const abortError = new Error('aborted by test')
+    const body = streamBody('a', streamDelay(5_000), 'b')
+    const stream = streamFromScript(body, controller.signal)
+    const readPromise = readAll(stream)
+    controller.abort(abortError)
+    await expect(readPromise).rejects.toBe(abortError)
+    expect(body.cancelCount).toBe(0)
+  })
+
+  it('errors with the signal reason when aborted during a stall', async () => {
+    const controller = new AbortController()
+    const abortError = new Error('stall abort')
+    const body = streamBody(streamStall())
+    const readPromise = readAll(streamFromScript(body, controller.signal))
+    controller.abort(abortError)
+    await expect(readPromise).rejects.toBe(abortError)
+  })
+
+  it('errors immediately when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    const abortError = new Error('pre-aborted')
+    controller.abort(abortError)
+    const readPromise = readAll(streamFromScript(streamBody('never'), controller.signal))
+    await expect(readPromise).rejects.toBe(abortError)
+  })
+
+  it('produces independent streams per call, aggregating cancels on the handle', async () => {
+    const body = streamBody('x', streamStall())
+    const readerA = streamFromScript(body, undefined).getReader()
+    const readerB = streamFromScript(body, undefined).getReader()
+    await readerA.read()
+    await readerB.read()
+    await readerA.cancel('a done')
+    await readerB.cancel('b done')
+    expect(body.cancelCount).toBe(2)
+    expect(body.lastCancelReason).toBe('b done')
+  })
+})
+
+describe('drainScript', () => {
+  it('collects all chunks honoring delays', async () => {
+    const body = streamBody('slow', streamDelay(60), ' body')
+    const start = Date.now()
+    const bytes = await drainScript(body, undefined)
+    expect(new TextDecoder().decode(bytes)).toBe('slow body')
+    expect(Date.now() - start).toBeGreaterThanOrEqual(50)
+  })
+
+  it('rejects on streamError', async () => {
+    const cut = new Error('cut')
+    await expect(drainScript(streamBody('x', streamError(cut)), undefined)).rejects.toBe(cut)
+  })
+
+  it('walks independently of other consumptions', async () => {
+    const body = streamBody('same')
+    expect(new TextDecoder().decode(await drainScript(body, undefined))).toBe('same')
+    expect(new TextDecoder().decode(await drainScript(body, undefined))).toBe('same')
   })
 })

--- a/test/mock/streamBody.test.ts
+++ b/test/mock/streamBody.test.ts
@@ -99,6 +99,19 @@ describe('streamFromScript', () => {
     expect(Array.from(value)).toEqual([1, 2, 3])
   })
 
+  it.runIf(typeof Buffer !== 'undefined')(
+    'copies Buffer input so later mutation of the buffer does not leak in',
+    async () => {
+      const buf = Buffer.from([1, 2, 3])
+      const body = streamBody(buf)
+      const reader = streamFromScript(body, undefined).getReader()
+      buf[0] = 9
+      const {value} = await reader.read()
+      if (value === undefined) throw new Error('expected a chunk')
+      expect(Array.from(value)).toEqual([1, 2, 3])
+    },
+  )
+
   it('waits for streamDelay between chunks', async () => {
     const body = streamBody('a', streamDelay(60), 'b')
     const start = Date.now()
@@ -129,6 +142,19 @@ describe('streamFromScript', () => {
     await reader.cancel(reason)
     expect(body.cancelCount).toBe(1)
     expect(body.lastCancelReason).toBe(reason)
+  })
+
+  it('cancel() interrupts a pending delay wait so it settles promptly', async () => {
+    const body = streamBody('a', streamDelay(60_000), 'b')
+    const reader = streamFromScript(body, undefined).getReader()
+    const start = Date.now()
+    const first = await reader.read()
+    expect(new TextDecoder().decode(first.value)).toBe('a')
+
+    await reader.cancel('bail')
+
+    expect(Date.now() - start).toBeLessThan(1000)
+    expect(body.cancelCount).toBe(1)
   })
 
   it('errors with the signal reason when aborted mid-delay', async () => {

--- a/test/mock/streamBody.test.ts
+++ b/test/mock/streamBody.test.ts
@@ -10,6 +10,8 @@ import {
   drainScript,
   streamFromScript,
 } from '../../src/mock/streamBody'
+import {mockMatchers} from '../../src/mock/vitestMatchers'
+import '../../src/_exports/vitest'
 
 describe('streamBody()', () => {
   it('builds a StreamBody with the script and zeroed counters', () => {
@@ -188,5 +190,39 @@ describe('drainScript', () => {
     const body = streamBody('same')
     expect(new TextDecoder().decode(await drainScript(body, undefined))).toBe('same')
     expect(new TextDecoder().decode(await drainScript(body, undefined))).toBe('same')
+  })
+})
+
+describe('toHaveBeenCancelled matcher', () => {
+  it('registers via the get-it/vitest entry, including negation', async () => {
+    const fresh = streamBody('x')
+    expect(fresh).not.toHaveBeenCancelled()
+
+    const body = streamBody('x', streamStall())
+    const reader = streamFromScript(body, undefined).getReader()
+    await reader.read()
+    await reader.cancel('done')
+    expect(body).toHaveBeenCancelled()
+  })
+
+  it('fails for non-StreamBody values', () => {
+    const result = mockMatchers.toHaveBeenCancelled({})
+    expect(result.pass).toBe(false)
+    expect(result.message()).toContain('streamBody()')
+  })
+
+  it('reports pass/fail based on cancelCount, with reason in the message', async () => {
+    const body = streamBody('x', streamStall())
+    expect(mockMatchers.toHaveBeenCancelled(body).pass).toBe(false)
+    expect(mockMatchers.toHaveBeenCancelled(body).message()).toContain('never')
+
+    const reader = streamFromScript(body, undefined).getReader()
+    await reader.read()
+    await reader.cancel(new Error('bail'))
+
+    const result = mockMatchers.toHaveBeenCancelled(body)
+    expect(result.pass).toBe(true)
+    expect(result.message()).toContain('1 time(s)')
+    expect(result.message()).toContain('bail')
   })
 })


### PR DESCRIPTION
## Motivation

`get-it/mock` could only deliver a response body as a single synchronous chunk, which makes streaming consumers untestable against it. The sanity-io/cli get-it v9 migration (sanity-io/cli#1534) had to hand-build `ReadableStream`s and mock the requester module to test its backup `downloadStream` code: chunked delivery, a body that stalls forever, and asserting that the consumer cancelled the download were all impossible with the mock.

This PR addresses https://github.com/sanity-io/get-it/issues/618 although with a different API than proposed (personally find this API easier, although a stream is more direct. `respondPersist` etc doesn't work with streams.)

## What's new

- `streamBody(...parts)` declares a response body as a script of chunks (`string` | `Uint8Array`) and directives, passed via the existing `body` field:
  - `streamDelay(ms)`: pause between chunks
  - `streamStall()`: terminal, the body never closes (ends only via consumer cancel or signal abort)
  - `streamError(err)`: terminal, errors the stream mid-download (simulates a connection cut)
- A fresh stream is built per consumption, so `respondPersist` works; scripts are validated eagerly (terminal-not-last, bad delays) with index-carrying `TypeError`s
- Faithful abort semantics: aborting the request signal errors the body with the abort reason, exactly like real fetch/undici; consumer cancels interrupt in-flight delays and stalls immediately
- Observability: the `streamBody()` return value is the handle (`cancelCount`, `lastCancelReason`, aggregated across consumptions), plus a new `toHaveBeenCancelled()` matcher in `get-it/vitest`
- Buffered reads stay faithful: `text()`/`arrayBuffer()` drain the script with the same timing, so total-deadline timeout behavior is testable too; the response-level `delay` option still controls time-to-headers and composes with the script
- Binary-safe: chunks are snapshot-copied with `new Uint8Array()` (immune to `Buffer#slice()` shared-memory semantics)

## Notes

- The body stream is constructed lazily on the response object, so buffered consumption never registers abort listeners (no listener accumulation with shared signals + `respondPersist`)
- Together with structured timeouts (#616), the sanity-io/cli `downloadStream` test patterns can run entirely against the real get-it request layer with an injected mock fetch: the integration suite includes that exact stall + cancel scenario
- Raw `ReadableStream` passthrough was deliberately not added: single-use bodies break `respondPersist`, and the script form covers the use cases

## Testing

- New `test/mock/streamBody.test.ts`: script validation, chunk encoding and snapshot copies (incl. a Buffer-mutation guard), delay timing, stall + cancel (prompt interruption, counters), `streamError`, abort-mid-body with reason identity, independence across consumptions, and the matcher (direct + registered via `get-it/vitest`, incl. negation)
- `test/mock/createMockFetch.test.ts`: integration through `createRequester({fetch: mock.fetch})` for `as: 'stream'` chunked reads, buffered drains with delays, mid-body error rejection, delay/script composition, `respondPersist` independence, a 15-request shared-signal regression test, and the sanity-io/cli#1534-shaped stall/cancel scenario
- Full suite 433/433 across all runtime pools; format, lint, and typecheck clean