### PR TITLE
feat(mock): expose raw fetch init on RecordedRequest

### DIFF
--- a/.changeset/pr-621.md
+++ b/.changeset/pr-621.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat(mock): expose raw fetch init on RecordedRequest

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -1,4 +1,4 @@
-import type {FetchFunction, FetchResponse} from '../types'
+import type {FetchFunction, FetchInit, FetchResponse} from '../types'
 import {
   blobToBytes,
   contentTypeFor,
@@ -58,6 +58,13 @@ export interface RecordedRequest {
   query: Record<string, string>
   headers: Headers
   body: unknown
+  /**
+   * The raw init object passed to the mock fetch call, verbatim (or `undefined`
+   * if the fetch was called without one). Useful for asserting on transport-level
+   * fields like `signal`, or non-standard fields forwarded by composed fetches
+   * (e.g. Next.js `cache`/`next`) — reach those via narrowing (`'next' in init`).
+   */
+  init: FetchInit | undefined
 }
 
 /**
@@ -706,6 +713,7 @@ export function createMockFetch(): MockFetch {
       query,
       headers: normalizedHeaders,
       body,
+      init,
     })
 
     // Normalize native-type expected bodies once (async for Blob/FormData), cached per handler.

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -407,6 +407,65 @@ describe('createMockFetch', () => {
       expect(requests[0].headers).toBeInstanceOf(Headers)
       expect(requests[0].query).toEqual({limit: '10', offset: '0'})
     })
+
+    it('records the raw fetch init, exposing transport-level fields like signal', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/api/docs').respond({status: 200, body: {items: []}})
+
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: mock.fetch,
+        httpErrors: false,
+      })
+
+      const controller = new AbortController()
+      await request({url: '/api/docs', signal: controller.signal, as: 'json'})
+
+      const requests = mock.getRequests()
+      expect(requests).toHaveLength(1)
+      const {init} = requests[0]
+      if (!init) throw new Error('expected init to be recorded')
+      expect(init.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    it('records non-standard init fields forwarded by composed fetches', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/api/docs').respond({status: 200, body: {items: []}})
+
+      // Mirrors e.g. a Next.js setup where a wrapping fetch forwards extra
+      // init fields (`cache`, `next`) to the underlying transport.
+      const request = createRequester({
+        base: 'https://api.example.com',
+        fetch: (input, init) => {
+          const forwarded = {...init, cache: 'force-cache', next: {revalidate: 60}}
+          return mock.fetch(input, forwarded)
+        },
+        httpErrors: false,
+      })
+
+      await request({url: '/api/docs', as: 'json'})
+
+      const requests = mock.getRequests()
+      expect(requests).toHaveLength(1)
+      const {init} = requests[0]
+      if (!init) throw new Error('expected init to be recorded')
+      if (!('cache' in init) || !('next' in init)) {
+        throw new Error('expected non-standard init fields to be recorded')
+      }
+      expect(init.cache).toBe('force-cache')
+      expect(init.next).toEqual({revalidate: 60})
+    })
+
+    it('records init as undefined when fetch is called without one', async () => {
+      const mock = createMockFetch()
+      mock.on('GET', '/api/docs').respond({status: 200, body: {items: []}})
+
+      await mock.fetch('https://api.example.com/api/docs')
+
+      const requests = mock.getRequests()
+      expect(requests).toHaveLength(1)
+      expect(requests[0].init).toBeUndefined()
+    })
   })
 
   describe('assertAllConsumed', () => {


### PR DESCRIPTION
## Motivation

During the @sanity/client v9 migration (sanity-io/client#1217), tests needed to assert on transport-level init fields like `signal`, and on non-standard fields forwarded by composed fetches (Next.js `cache`/`next`). Since the mock did not record the init, the test suite had to wrap the injected fetch with a capturing spy in five places. Recording the init on `RecordedRequest` removes that boilerplate.

## Changes

- Add an `init` field to `RecordedRequest`, holding the init object passed to the mock fetch call, verbatim (`undefined` when the fetch was called without one)
- Typed as `FetchInit | undefined`: runtime extras like Next.js `next`/`cache` are reachable via narrowing (`'next' in init`)
- Tests covering: `signal` exposure, non-standard init fields forwarded by a composed fetch, and `undefined` when no init is passed

## Test results

- `pnpm test`: 469 passed (27 files)
- `pnpm typecheck` and `pnpm lint`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API on the mock helper with narrow recording logic and tests; no change to live fetch or request matching behavior.
> 
> **Overview**
> **`RecordedRequest`** from `createMockFetch` now includes **`init`**: the exact `FetchInit` passed into the mock `fetch` (or `undefined` when omitted), so tests can assert on transport options like **`signal`** and framework-specific fields (e.g. Next.js **`cache`** / **`next`**) without wrapping fetch in a spy.
> 
> The mock’s request recorder stores that reference alongside the existing normalized fields. New tests cover `signal`, forwarded non-standard init, and the no-init case. Packaged as a **minor** changeset for `get-it`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9951538cc75d3b9043114c7e58b3d780466b923b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->