### PR TITLE
feat(mock): track request-signal aborts on StreamBody

### DIFF
--- a/.changeset/pr-622.md
+++ b/.changeset/pr-622.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat(mock): track request-signal aborts on StreamBody

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -24,7 +24,7 @@ export type StreamPart = string | Uint8Array | StreamDirective
  * Marker object recognized in `MockResponseDef.body`, produced by
  * {@link streamBody}. Also serves as the observability handle: a fresh
  * stream is built from the script for every consumption, and consumer
- * cancellations are aggregated on this object.
+ * cancellations and request-signal aborts are aggregated on this object.
  * @public
  */
 export class StreamBody {
@@ -32,6 +32,10 @@ export class StreamBody {
   cancelCount = 0
   /** The reason passed to the most recent cancel, if any. */
   lastCancelReason: unknown = undefined
+  /** Number of times a request's abort signal terminated a stream produced from this script. */
+  abortCount = 0
+  /** The abort reason from the most recent request-signal abort, if any. */
+  lastAbortReason: unknown = undefined
   /** The validated script. @internal */
   readonly script: ReadonlyArray<StreamPart>
 
@@ -164,7 +168,7 @@ function stallUntilAborted(signal: AbortSignal | undefined): Promise<never> {
  * Build a fresh `ReadableStream` that plays back a {@link StreamBody} script.
  * Each call produces an independent stream (persist-safe). Aborting `signal`
  * errors the stream with the signal's reason, mirroring real fetch behavior;
- * consumer cancellation is recorded on the handle.
+ * both consumer cancellation and signal aborts are recorded on the handle.
  * @internal
  */
 export function streamFromScript(
@@ -188,10 +192,19 @@ export function streamFromScript(
     }
   }
 
+  // The abort listener is removed on close/error/cancel, so an abort is only
+  // recorded when the signal actually terminated a live stream — a cancelled
+  // stream whose signal later aborts does not count.
+  const recordAbort = (reason: unknown) => {
+    body.abortCount++
+    body.lastAbortReason = reason
+  }
+
   return new ReadableStream<Uint8Array>({
     start(controller) {
       if (!signal) return
       if (signal.aborted) {
+        recordAbort(signal.reason)
         controller.error(signal.reason)
         return
       }
@@ -202,6 +215,7 @@ export function streamFromScript(
       // this listener is safe even when pull() also rejects on the same abort.
       onAbort = () => {
         removeAbortListener()
+        recordAbort(signal.reason)
         controller.error(signal.reason)
       }
       signal.addEventListener('abort', onAbort, {once: true})

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1762,6 +1762,10 @@ describe('createMockFetch', () => {
       const pendingRead = reader.read()
       controller.abort(abortError)
       await expect(pendingRead).rejects.toBe(abortError)
+      // The teardown is observable on the handle: counted as a signal abort,
+      // not a consumer cancel (the "did the client disconnect?" leak test).
+      expect(body.abortCount).toBe(1)
+      expect(body.lastAbortReason).toBe(abortError)
       expect(body.cancelCount).toBe(0)
     })
   })

--- a/test/mock/streamBody.test.ts
+++ b/test/mock/streamBody.test.ts
@@ -19,6 +19,8 @@ describe('streamBody()', () => {
     expect(body).toBeInstanceOf(StreamBody)
     expect(body.cancelCount).toBe(0)
     expect(body.lastCancelReason).toBeUndefined()
+    expect(body.abortCount).toBe(0)
+    expect(body.lastAbortReason).toBeUndefined()
     expect(body.script).toHaveLength(4)
   })
 
@@ -166,6 +168,8 @@ describe('streamFromScript', () => {
     controller.abort(abortError)
     await expect(readPromise).rejects.toBe(abortError)
     expect(body.cancelCount).toBe(0)
+    expect(body.abortCount).toBe(1)
+    expect(body.lastAbortReason).toBe(abortError)
   })
 
   it('errors with the signal reason when aborted during a stall', async () => {
@@ -175,14 +179,55 @@ describe('streamFromScript', () => {
     const readPromise = readAll(streamFromScript(body, controller.signal))
     controller.abort(abortError)
     await expect(readPromise).rejects.toBe(abortError)
+    expect(body.abortCount).toBe(1)
+    expect(body.lastAbortReason).toBe(abortError)
   })
 
   it('errors immediately when the signal is already aborted', async () => {
     const controller = new AbortController()
     const abortError = new Error('pre-aborted')
     controller.abort(abortError)
-    const readPromise = readAll(streamFromScript(streamBody('never'), controller.signal))
+    const body = streamBody('never')
+    const readPromise = readAll(streamFromScript(body, controller.signal))
     await expect(readPromise).rejects.toBe(abortError)
+    expect(body.abortCount).toBe(1)
+    expect(body.lastAbortReason).toBe(abortError)
+  })
+
+  it('counts aborts and cancels independently on the handle', async () => {
+    const controller = new AbortController()
+    const body = streamBody('chunk', streamStall())
+    const reader = streamFromScript(body, controller.signal).getReader()
+    const first = await reader.read()
+    expect(new TextDecoder().decode(first.value)).toBe('chunk')
+
+    const abortError = new Error('client tore down the connection')
+    const pendingRead = reader.read()
+    controller.abort(abortError)
+    await expect(pendingRead).rejects.toBe(abortError)
+
+    expect(body.abortCount).toBe(1)
+    expect(body.lastAbortReason).toBe(abortError)
+    expect(body.cancelCount).toBe(0)
+    expect(body.lastCancelReason).toBeUndefined()
+  })
+
+  it('consumer cancel() increments cancelCount only, even with a signal attached', async () => {
+    const controller = new AbortController()
+    const body = streamBody('chunk', streamStall())
+    const reader = streamFromScript(body, controller.signal).getReader()
+    await reader.read()
+
+    const reason = new Error('consumer done')
+    await reader.cancel(reason)
+    expect(body.cancelCount).toBe(1)
+    expect(body.lastCancelReason).toBe(reason)
+    expect(body.abortCount).toBe(0)
+
+    // Aborting the signal after the stream was cancelled must not be counted:
+    // the stream was already terminated by the consumer, not the signal.
+    controller.abort(new Error('late abort'))
+    expect(body.abortCount).toBe(0)
   })
 
   it('produces independent streams per call, aggregating cancels on the handle', async () => {


### PR DESCRIPTION
## Motivation

The `StreamBody` handle exposes `cancelCount`, but that only counts consumer-initiated `reader.cancel()`. When a request's `AbortSignal` fires - which is how fetch cancellation manifests in practice, e.g. `EventSource.close()` tearing down an SSE connection - the stream errors and nothing is counted on the handle.

The @sanity/client v9 migration (sanity-io/client#1217) wants to assert "did the client tear down the connection?" directly from the handle. Today its SSE-unsubscribe leak test has to capture `init.signal` via a fetch spy instead. With this change, `streamStall()` plus one assertion is a natural leak test:

```ts
const body = streamBody('data: {}\n\n', streamStall())
// ... subscribe, then unsubscribe ...
expect(body.abortCount).toBe(1)
```

## Changes

- Add `abortCount` and `lastAbortReason` to the `StreamBody` handle, mirroring the existing `cancelCount` / `lastCancelReason` pair
- Record an abort in `streamFromScript` when the request signal terminates a live stream: via the abort listener registered in `start()`, and in the already-aborted-at-construction branch
- Since the abort listener is removed on close / `streamError` / consumer cancel, an abort is counted exactly once per consumption and only when the signal actually terminated the stream - a stream cancelled by the consumer whose signal later aborts does not count
- Aborts are counted mid-delay and mid-stall (`streamStall()`), matching how an SSE teardown looks in practice

## Tests

- Request signal aborted mid-stream increments `abortCount` (and not `cancelCount`), recording the reason
- Consumer `reader.cancel()` still increments `cancelCount` only, and a late signal abort after cancel is not counted
- `streamStall()` scenario where aborting the request signal is observable from the handle, both at the stream level and through a full `createRequester` request (the leak-test shape)
- Pre-aborted signal at stream construction is counted

`pnpm test test/mock/` (227 passed), `pnpm typecheck`, and `pnpm lint` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mock-only observability API with clear semantics and broad test coverage; no production fetch or auth paths changed.
> 
> **Overview**
> **`StreamBody`** now exposes **`abortCount`** and **`lastAbortReason`**, parallel to the existing cancel counters, so tests can assert that a fetch **`AbortSignal`** tore down a streaming mock (e.g. SSE unsubscribe) without spying on `init.signal`.
> 
> **`streamFromScript`** records an abort when the request signal ends a live stream—on the abort listener and when the signal is already aborted at construction. Aborts are **not** double-counted with **`reader.cancel()`**: the abort listener is cleared on cancel/close/error, so a late signal abort after consumer cancel does not increment **`abortCount`**.
> 
> Tests cover mid-delay, mid-stall, pre-aborted signals, abort vs cancel independence, and the full **`createMockFetch`** streaming path. Minor release noted in changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87472052329f9b0f4caad5d3a156d4f631375b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->