### PR TITLE
feat(retry): honor per-request maxRetries option

### DIFF
--- a/.changeset/pr-623.md
+++ b/.changeset/pr-623.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat(retry): honor per-request maxRetries option

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ const request = createRequester({
 })
 ```
 
+A per-request `maxRetries` option overrides the retry middleware's configured value for that request (`0` disables retries, higher values allow more attempts).
+
 ## Runtime proxy support
 
 In Node.js and Bun, `createRequester` automatically uses an undici-based fetch that reads proxy configuration from environment variables.

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -104,16 +104,24 @@ const request = createRequester({
 })
 ```
 
-### No per-request retry overrides
+### Per-request retry overrides limited to `maxRetries`
 
-v8 allowed retry settings on individual requests:
+v8 allowed all retry settings on individual requests:
 
 ```ts
 // v8
 await request({url: '/critical', maxRetries: 10, shouldRetry: customPredicate})
 ```
 
-v9's retry configuration is set once when creating the middleware. To use different retry behavior for different requests, create separate request instances:
+v9 keeps per-request `maxRetries` — it overrides the middleware's configured value for that request, in both directions:
+
+```ts
+// v9
+await request({url: '/critical', maxRetries: 10})
+await request({url: '/no-retries', maxRetries: 0})
+```
+
+`retryDelay` and `shouldRetry` are set once when creating the middleware. To use different values for different requests, create separate request instances:
 
 ```ts
 // v9

--- a/src/middleware/retry.ts
+++ b/src/middleware/retry.ts
@@ -17,7 +17,8 @@ interface RetryOptions {
  *   `retryDelay` returns the delay in ms for a given attempt (default: exponential
  *   backoff `100 * 2^attempt + random(0–100)`), and `shouldRetry` is a predicate
  *   that decides if an error is retryable (default: transient network errors on
- *   GET/HEAD only).
+ *   GET/HEAD only). A per-request `maxRetries` option overrides the construction
+ *   value for that request, in both directions.
  * @returns A wrapping middleware that adds retry logic.
  *
  * @example
@@ -30,7 +31,7 @@ interface RetryOptions {
  * @public
  */
 export function retry(opts?: RetryOptions): WrappingMiddleware {
-  const maxRetries = opts?.maxRetries ?? 5
+  const defaultMaxRetries = opts?.maxRetries ?? 5
   const retryDelay = opts?.retryDelay ?? getRetryDelay
   const shouldRetry = opts?.shouldRetry ?? isRetryableRequest
 
@@ -38,6 +39,10 @@ export function retry(opts?: RetryOptions): WrappingMiddleware {
     options: RequestOptions,
     next: (reqOpts: RequestOptions) => Promise<BufferedResponse>,
   ): Promise<BufferedResponse> {
+    // Per-request `maxRetries` overrides the construction value in both
+    // directions — `0` disables retries, a higher value extends the cap.
+    const maxRetries =
+      typeof options.maxRetries === 'number' ? options.maxRetries : defaultMaxRetries
     let lastError: unknown
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,6 +207,12 @@ export interface RequestOptions {
    * workers) return the real 3xx response, so its status and headers are readable.
    */
   redirect?: 'error' | 'follow' | 'manual'
+  /**
+   * Max retry attempts for this request when the `retry` middleware is used.
+   * Overrides the middleware's construction config in both directions —
+   * `0` disables retries, a value above the configured cap allows more attempts.
+   */
+  maxRetries?: number
   /** Arbitrary metadata — not used by get-it, but available to middleware. */
   meta?: {
     /** Custom request identifier used by the `debug` middleware in log output. */

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -34,6 +34,77 @@ describe('retry middleware', {timeout: 15000}, () => {
     await expect(request('/permafail')).rejects.toThrow()
   })
 
+  it.runIf(canTestNetworkErrors)('per-request maxRetries of 0 disables retries', async () => {
+    let attempts = 0
+    const request = createRequester({
+      base: baseUrl,
+      httpErrors: false,
+      middleware: [
+        retry({maxRetries: 5, retryDelay: () => 10}),
+        async (opts, next) => {
+          attempts++
+          return next(opts)
+        },
+      ],
+    })
+    await expect(request({url: '/permafail', maxRetries: 0})).rejects.toThrow()
+    expect(attempts).toBe(1)
+  })
+
+  it.runIf(canTestNetworkErrors)(
+    'per-request maxRetries below instance cap is honored',
+    async () => {
+      let attempts = 0
+      const request = createRequester({
+        base: baseUrl,
+        httpErrors: false,
+        middleware: [
+          retry({maxRetries: 5, retryDelay: () => 10}),
+          async (opts, next) => {
+            attempts++
+            return next(opts)
+          },
+        ],
+      })
+      await expect(request({url: '/permafail', maxRetries: 1})).rejects.toThrow()
+      expect(attempts).toBe(2)
+    },
+  )
+
+  it.runIf(canTestNetworkErrors)(
+    'per-request maxRetries above instance cap is honored',
+    async () => {
+      const request = createRequester({
+        base: baseUrl,
+        httpErrors: false,
+        middleware: [retry({maxRetries: 1, retryDelay: () => 10})],
+      })
+      // Succeeds on the 4th attempt — beyond the instance cap of 1 retry (2 attempts)
+      const res = await request({url: `/fail?uuid=${Math.random()}&n=4`, maxRetries: 3})
+      expect(res.status).toBe(200)
+    },
+  )
+
+  it.runIf(canTestNetworkErrors)(
+    'falls back to construction config when no per-request maxRetries',
+    async () => {
+      let attempts = 0
+      const request = createRequester({
+        base: baseUrl,
+        httpErrors: false,
+        middleware: [
+          retry({maxRetries: 2, retryDelay: () => 10}),
+          async (opts, next) => {
+            attempts++
+            return next(opts)
+          },
+        ],
+      })
+      await expect(request('/permafail')).rejects.toThrow()
+      expect(attempts).toBe(3)
+    },
+  )
+
   it('does not retry HTTP errors by default', async () => {
     let attempts = 0
     const request = createRequester({


### PR DESCRIPTION
## Summary

Restores v8 parity for per-request retry caps. The retry middleware now reads `options.maxRetries` from the per-request options when it is a number, falling back to the construction config (default 5).

- A per-request value fully overrides the instance value, in both directions: `maxRetries: 0` disables retries for that request, and a value above the instance cap allows more attempts
- `shouldRetry` continues to receive the per-request options unchanged, so custom predicates keep working
- `maxRetries` is added to the `RequestOptions` type with JSDoc
- README gets a one-line mention, and the v9 migration guide section on per-request overrides is updated to reflect that `maxRetries` is supported natively again (only `retryDelay`/`shouldRetry` remain construction-only)

## Motivation

In v8 the retry middleware honored `options.maxRetries` per request. v9 dropped this, so downstreams that expose per-request retry opt-out - @sanity/client does, on `client.request()` and the raw requester (see sanity-io/client#1217) - had to reimplement the cap inside a custom `shouldRetry` via request metadata. That workaround can only lower the effective cap, not extend it; native support does both.

## Tests

New tests in `test/retry.test.ts`:

- per-request `maxRetries: 0` performs no retries even when instance config allows 5
- per-request value below the instance cap is honored
- per-request value above the instance cap is honored (extends)
- absent per-request value falls back to construction config

Verified with `pnpm test` (470 passed), `pnpm typecheck`, and `pnpm lint`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to retry attempt counting with new tests; default behavior is unchanged when `maxRetries` is not set on the request.
> 
> **Overview**
> Restores **v8-style per-request retry caps** for the `retry` middleware: each request can pass `maxRetries` on `RequestOptions`, which fully overrides the value from `retry({ maxRetries })` for that call only.
> 
> **`0` turns off retries** even when the instance allows more; a **higher number raises the cap** beyond the middleware default. If `maxRetries` is omitted on the request, behavior is unchanged and still uses the construction-time default (5 when unset).
> 
> Types and docs are aligned: `RequestOptions.maxRetries` is documented, README notes the override, and the v9 migration guide now says only `maxRetries` is per-request (`retryDelay` / `shouldRetry` stay middleware-only). New retry tests cover disable, lower cap, higher cap, and fallback to instance config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b66992fd71499047f6fad448a59c58c306cb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->