### PR TITLE
fix(mock): lowercase header names defensively in header matching

### DIFF
--- a/.changeset/pr-624.md
+++ b/.changeset/pr-624.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': patch
+---
+
+fix(mock): lowercase header names defensively in header matching

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -152,13 +152,15 @@ function getContentType(headers: Headers): string | null {
 
 /**
  * Build a lowercased-key record of a request's headers for matching.
- * `Headers.forEach` already yields lowercased names.
+ * Spec-compliant `Headers.forEach` already yields lowercased names, but some
+ * implementations (eg happy-dom, see capricorn86/happy-dom#2249) preserve the
+ * original casing — lowercase defensively so matching stays case-insensitive.
  * @internal
  */
 function toHeaderRecord(headers: Headers): Record<string, string> {
   const record: Record<string, string> = {}
   headers.forEach((value, key) => {
-    record[key] = value
+    record[key.toLowerCase()] = value
   })
   return record
 }

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1,6 +1,6 @@
 import {createRequester} from 'get-it'
 import {retry} from 'get-it/middleware'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {createMockFetch} from '../../src/mock/createMockFetch'
 import {MockFetchError} from '../../src/mock/errors'
@@ -1596,6 +1596,66 @@ describe('createMockFetch', () => {
       })
 
       expect(res.status).toBe(200)
+    })
+
+    it('matches mixed-case request header names in non-lowercasing environments', async () => {
+      // Spec-compliant `Headers` iterate with lowercased names, but happy-dom
+      // preserves the original casing (capricorn86/happy-dom#2249). Running
+      // under `pnpm test:happy-dom`, this exercises that real-world case.
+      const mock = createMockFetch()
+      mock.on('GET', '/x', {headers: {authorization: 'Bearer token'}}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/x', {
+        method: 'GET',
+        headers: {Authorization: 'Bearer token'},
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('matches when the Headers implementation iterates original-case names', async () => {
+      // Minimal Headers-compatible fake that (like happy-dom, see
+      // capricorn86/happy-dom#2249) keeps original header-name casing during
+      // iteration, reproducing the non-conforming behavior in any environment.
+      class CasePreservingHeaders {
+        private entries = new Map<string, {name: string; value: string}>()
+        constructor(init?: CasePreservingHeaders | [string, string][] | Record<string, string>) {
+          if (init instanceof CasePreservingHeaders) {
+            init.forEach((value, name) => this.set(name, value))
+          } else if (Array.isArray(init)) {
+            for (const [name, value] of init) this.set(name, value)
+          } else if (init !== undefined) {
+            for (const name of Object.keys(init)) this.set(name, init[name])
+          }
+        }
+        get(name: string): string | null {
+          return this.entries.get(name.toLowerCase())?.value ?? null
+        }
+        has(name: string): boolean {
+          return this.entries.has(name.toLowerCase())
+        }
+        set(name: string, value: string): void {
+          this.entries.set(name.toLowerCase(), {name, value})
+        }
+        forEach(callback: (value: string, name: string) => void): void {
+          for (const {name, value} of this.entries.values()) callback(value, name)
+        }
+      }
+
+      vi.stubGlobal('Headers', CasePreservingHeaders)
+      try {
+        const mock = createMockFetch()
+        mock.on('GET', '/x', {headers: {authorization: 'Bearer token'}}).respond({status: 200})
+
+        const res = await mock.fetch('https://api.example.com/x', {
+          method: 'GET',
+          headers: {Authorization: 'Bearer token'},
+        })
+
+        expect(res.status).toBe(200)
+      } finally {
+        vi.unstubAllGlobals()
+      }
     })
 
     it('reports a headers diff on mismatch', async () => {


### PR DESCRIPTION
### Problem

The mock module's header matching builds a record from `Headers` iteration and looks names up lowercased, assuming spec-compliant `Headers` that iterate with lowercase names. happy-dom's `Headers` preserves the original casing during iteration (capricorn86/happy-dom#2249), so mixed-case header names like `Authorization` never match when tests run in simulated-browser environments.

This bites downstream consumers: the @sanity/client v9 migration (sanity-io/client#1217) currently wraps the mock fetch to normalize header casing as a workaround.

### Fix

- `toHeaderRecord` now lowercases keys defensively (`record[key.toLowerCase()] = value`) instead of relying on spec-compliant iteration, with a comment explaining why
- This was the only spot in `src/mock/` building header records from `Headers` iteration; the vitest matchers use `headers.get()`, which is case-insensitive even in happy-dom

### Tests

- Regression test sending a mixed-case `Authorization` header against a lowercase-constrained handler: this reproduces the real-world failure when the suite runs under `pnpm test:happy-dom` (verified failing before the fix, 2 failures under happy-dom)
- A second test stubs the global `Headers` with a minimal case-preserving fake so the regression is also guarded in the default Node run (verified failing before the fix)

### Verification

- `pnpm test` (full Node suite): 468 passed
- `pnpm test:happy-dom`: 427 passed, 22 skipped
- `pnpm typecheck` and `pnpm lint`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to test mock header normalization with added tests; no production fetch or auth paths affected.
> 
> **Overview**
> **Mock header matching** now lowercases header names when building the request header record in `toHeaderRecord`, so handler constraints like `{authorization: '…'}` still match when the request sends `Authorization` and the `Headers` implementation preserves original casing during `forEach` (e.g. happy-dom).
> 
> Adds regression coverage for mixed-case request headers under happy-dom and via a stubbed case-preserving `Headers` in Node. Ships as a **patch** changeset for `get-it`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8ccf46111fee995c7366807f4ad8a416b44277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->