### PR TITLE
feat: rejection-only timeouts via {signal: false}

### DIFF
--- a/.changeset/pr-626.md
+++ b/.changeset/pr-626.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat: rejection-only timeouts via {signal: false}

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ const request = createRequester({
 - `total` — the existing deadline. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with a `TimeoutError` DOMException, which the `retry()` middleware never retries. When combined with the retry() middleware, the deadline applies per attempt - each retry gets a fresh total timer.
 - `headers` — time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. Because the timer lives inside the middleware chain, each retry attempt gets a fresh timer — no middleware ordering requirements.
 
+### Escape hatch: rejection-only timeouts (`signal: false`)
+
+By default, timeouts attach an abort signal to the fetch init - keep it that way unless an environment forces your hand. The known case: Next.js' patched fetch treats any signal-carrying request as opted out of React Request Memoization, so RSC consumers would otherwise have to choose between timeouts and memoization. For that situation, `timeout: {total: 30_000, signal: false}` keeps the timeouts (both `total` and `headers`) as pure rejections: the request promise still rejects with the same errors at the deadline, but nothing is attached to the fetch init.
+
+Understand what you are giving up: when a timeout wins, the underlying request is not torn down - it keeps running to completion in the background, holding its connection until the server finishes on its own. A caller-provided `signal` is passed through untouched and still aborts. In `as: 'stream'` mode, `total` only covers up to response headers (a stream already handed to you cannot be retracted).
+
 For long-running streaming downloads, disable the total deadline and keep a headers timeout:
 
 ```ts
@@ -168,7 +174,7 @@ const promise = request({url: '/slow', signal: controller.signal})
 controller.abort()
 ```
 
-Timeout and user-provided signals are combined automatically with `AbortSignal.any()`.
+Timeout and user-provided signals are combined automatically with `AbortSignal.any()` - unless the timeout is rejection-only (`timeout: {signal: false}`), in which case the user-provided signal is passed through as-is.
 
 ## Middleware
 

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -138,17 +138,21 @@ export function createRequester(
       controller && init.signal
         ? AbortSignal.any([init.signal, controller.signal])
         : (controller?.signal ?? init.signal)
-    const fetching = Promise.resolve(
-      controller ? fetchFn(url, {...init, signal}) : fetchFn(url, init),
-    )
+    // fetchFn is invoked inside the try so a synchronous throw still clears
+    // the headers timer — otherwise the orphaned deadline would later reject
+    // with nothing subscribed to it.
+    let fetching: Promise<FetchResponse> | undefined
     try {
+      fetching = Promise.resolve(
+        controller ? fetchFn(url, {...init, signal}) : fetchFn(url, init),
+      )
       return {response: await Promise.race([fetching, ...deadlines]), url, method, totalDeadline}
     } catch (reason) {
       // A deadline won the race (or the fetch itself failed): the fetch's
       // later settlement must not become an unhandled rejection. In
       // rejection-only mode the fetch was not aborted, so a late response
       // arrives with a dangling body — cancel it to release the connection.
-      fetching.then((response) => response.body?.cancel()).catch(() => {})
+      fetching?.then((response) => response.body?.cancel()).catch(() => {})
       throw reason
     } finally {
       clearTimeout(timer)

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -70,41 +70,86 @@ export function createRequester(
   async function performFetch(
     fetchFn: FetchFunction,
     opts: RequestOptions,
-  ): Promise<{response: FetchResponse; url: string; method: string}> {
-    const {totalMs, headersMs} = resolveTimeout(
+  ): Promise<{
+    response: FetchResponse
+    url: string
+    method: string
+    totalDeadline: Promise<never> | undefined
+  }> {
+    const {totalMs, headersMs, attachSignal} = resolveTimeout(
       opts.timeout !== undefined ? opts.timeout : instanceTimeout,
     )
-    const {url, init} = buildFetchArgs(opts, totalMs, instanceCredentials)
+    // In rejection-only mode the total deadline must not become a fetch-init
+    // signal, so it is withheld from buildFetchArgs and raced below instead.
+    const {url, init} = buildFetchArgs(
+      opts,
+      attachSignal ? totalMs : undefined,
+      instanceCredentials,
+    )
     const method = init.method ?? 'GET'
 
-    if (headersMs === undefined) {
-      return {response: await fetchFn(url, init), url, method}
+    // Rejection-only mode (`timeout: {signal: false}`): enforce the total
+    // deadline by racing the request promise instead of aborting the fetch,
+    // rejecting with the same TimeoutError DOMException the abort-based path
+    // produces. The fetch itself keeps running to completion in the
+    // background — the caller opted out of teardown (e.g. so Next.js RSC
+    // request memoization stays enabled) — and its late settlement is
+    // swallowed in the catch block below.
+    const totalDeadline =
+      !attachSignal && totalMs !== undefined
+        ? rejectAfterTimeout(
+            totalMs,
+            new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
+          )
+        : undefined
+
+    if (headersMs === undefined && totalDeadline === undefined) {
+      return {response: await fetchFn(url, init), url, method, totalDeadline}
     }
 
-    // Created eagerly so the stack trace points at the request call site
-    // rather than an empty timer-callback stack.
-    const timeoutError = new TimeoutError({url, method, timeoutMs: headersMs, phase: 'headers'})
-    const controller = new AbortController()
-    // Reject via Promise.race rather than relying on fetch to reject with the
-    // abort reason: workerd's fetch reconstructs the reason (losing its
-    // prototype, so `instanceof TimeoutError` breaks), and WebKit has dropped
-    // the reason — or ignored `AbortSignal.any`-derived aborts entirely.
+    // Deadlines competing with the fetch to settle the request promise.
+    const deadlines: Promise<never>[] = totalDeadline === undefined ? [] : [totalDeadline]
+
     let timer: ReturnType<typeof setTimeout> | undefined
-    const timedOut = new Promise<never>((_, reject) => {
-      timer = setTimeout(() => {
-        reject(timeoutError)
-        controller.abort(timeoutError)
-      }, headersMs)
-    })
-    const signal = init.signal
-      ? AbortSignal.any([init.signal, controller.signal])
-      : controller.signal
+    let controller: AbortController | undefined
+    if (headersMs !== undefined) {
+      // Created eagerly so the stack trace points at the request call site
+      // rather than an empty timer-callback stack.
+      const timeoutError = new TimeoutError({url, method, timeoutMs: headersMs, phase: 'headers'})
+      // Reject via Promise.race rather than relying on fetch to reject with the
+      // abort reason: workerd's fetch reconstructs the reason (losing its
+      // prototype, so `instanceof TimeoutError` breaks), and WebKit has dropped
+      // the reason — or ignored `AbortSignal.any`-derived aborts entirely.
+      // In rejection-only mode there is no controller — the race alone rejects.
+      controller = attachSignal ? new AbortController() : undefined
+      deadlines.push(
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(timeoutError)
+            controller?.abort(timeoutError)
+          }, headersMs)
+        }),
+      )
+    }
+
+    // Without a controller (rejection-only mode) the init is passed through
+    // untouched, so a caller-provided signal reaches fetch as-is.
+    const signal =
+      controller && init.signal
+        ? AbortSignal.any([init.signal, controller.signal])
+        : (controller?.signal ?? init.signal)
+    const fetching = Promise.resolve(
+      controller ? fetchFn(url, {...init, signal}) : fetchFn(url, init),
+    )
     try {
-      const fetching = Promise.resolve(fetchFn(url, {...init, signal}))
-      // If the timeout wins the race, the aborted fetch's later rejection
-      // must not become an unhandled rejection.
-      fetching.catch(() => {})
-      return {response: await Promise.race([fetching, timedOut]), url, method}
+      return {response: await Promise.race([fetching, ...deadlines]), url, method, totalDeadline}
+    } catch (reason) {
+      // A deadline won the race (or the fetch itself failed): the fetch's
+      // later settlement must not become an unhandled rejection. In
+      // rejection-only mode the fetch was not aborted, so a late response
+      // arrives with a dangling body — cancel it to release the connection.
+      fetching.then((response) => response.body?.cancel()).catch(() => {})
+      throw reason
     } finally {
       clearTimeout(timer)
     }
@@ -116,9 +161,11 @@ export function createRequester(
    */
   async function getItBuffered(opts: RequestOptions): Promise<BufferedResponse> {
     const fetchFn: FetchFunction = opts.fetch ?? instanceFetch ?? globalThis.fetch
-    const {response, url, method} = await performFetch(fetchFn, opts)
+    const {response, url, method, totalDeadline} = await performFetch(fetchFn, opts)
     const httpErrors = opts.httpErrors ?? instanceHttpErrors ?? true
-    return bufferAndCheck(response, httpErrors, url, method)
+    // The rejection-only total deadline covers body download too, so keep
+    // racing it while buffering (abort mode covers this via the init signal).
+    return raceDeadline(bufferAndCheck(response, httpErrors, url, method), totalDeadline)
   }
 
   // Compose wrapping middlewares around the core fetch
@@ -162,13 +209,18 @@ export function createRequester(
 
     async function getItStreamed(reqOpts: RequestOptions): Promise<BufferedResponse> {
       const fetchFn: FetchFunction = reqOpts.fetch ?? instanceFetch ?? globalThis.fetch
-      const {response, url, method} = await performFetch(fetchFn, reqOpts)
+      const {response, url, method, totalDeadline} = await performFetch(fetchFn, reqOpts)
       const httpErrors = reqOpts.httpErrors ?? instanceHttpErrors ?? true
 
       if (httpErrors && response.status >= 400) {
-        return bufferAndCheck(response, httpErrors, url, method)
+        return raceDeadline(bufferAndCheck(response, httpErrors, url, method), totalDeadline)
       }
 
+      // A rejection-only total deadline cannot govern the stream from here on
+      // — a stream already handed to the caller cannot be retracted — so with
+      // `signal: false` it only covers up to response headers. The deadline
+      // promise is pre-armed with a catch handler, so its eventual rejection
+      // stays handled.
       capturedResponse = response
       return createBufferedResponse(
         response.status,
@@ -258,6 +310,12 @@ export function createRequester(
 export interface ResolvedTimeout {
   totalMs: number | undefined
   headersMs: number | undefined
+  /**
+   * When `false` (`timeout: {signal: false}`), timeouts are rejection-only:
+   * the request promise rejects at the deadline but no timeout-derived abort
+   * signal is attached to the fetch init.
+   */
+  attachSignal: boolean
 }
 
 /**
@@ -270,11 +328,12 @@ export function resolveTimeout(
   value: number | false | TimeoutOptions | undefined,
 ): ResolvedTimeout {
   if (typeof value === 'number' || value === false) {
-    return {totalMs: enabledMs(value), headersMs: undefined}
+    return {totalMs: enabledMs(value), headersMs: undefined, attachSignal: true}
   }
   return {
     totalMs: value?.total === undefined ? 120_000 : enabledMs(value.total),
     headersMs: enabledMs(value?.headers),
+    attachSignal: value?.signal !== false,
   }
 }
 
@@ -295,6 +354,37 @@ function unrefTimer(timer: unknown): void {
     typeof timer.unref === 'function'
   ) {
     timer.unref()
+  }
+}
+
+/**
+ * Creates the rejection-only (`timeout: {signal: false}`) total deadline: a
+ * promise that rejects with `reason` once `ms` elapses. Pre-armed with a
+ * no-op catch handler so the rejection never becomes "unhandled" when the
+ * guarded work settles first — like the abort-based total deadline, the timer
+ * is unref'd rather than cleared, and firing after the race is won is
+ * harmless.
+ */
+function rejectAfterTimeout(ms: number, reason: unknown): Promise<never> {
+  const deadline = new Promise<never>((_, reject) => {
+    unrefTimer(setTimeout(() => reject(reason), ms))
+  })
+  deadline.catch(() => {})
+  return deadline
+}
+
+/**
+ * Awaits `work` while a rejection-only total deadline keeps racing it. If the
+ * deadline wins, `work` continues in the background — its eventual settlement
+ * is swallowed so it cannot become an unhandled rejection.
+ */
+async function raceDeadline<T>(work: Promise<T>, deadline: Promise<never> | undefined): Promise<T> {
+  if (deadline === undefined) return work
+  try {
+    return await Promise.race([work, deadline])
+  } catch (reason) {
+    work.catch(() => {})
+    throw reason
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,26 @@ export interface TimeoutOptions {
    * Disabled when omitted.
    */
   headers?: number | false
+  /**
+   * Whether timeouts attach an abort signal to the underlying `fetch`
+   * (the default, `true`). Set to `false` for rejection-only timeouts: the
+   * request promise still rejects with the same errors when a deadline
+   * elapses, but the fetch is NOT aborted — it keeps running to completion
+   * in the background.
+   *
+   * This is an escape hatch for environments like Next.js RSC, where any
+   * `signal` on the fetch init opts the request out of React Request
+   * Memoization — prefer the default unless such an environment forces your
+   * hand. The trade-off: a timed-out request keeps consuming a connection
+   * until the server finishes on its own. A caller-provided
+   * {@link RequestOptions.signal} is unaffected — it is passed through
+   * untouched and still aborts.
+   *
+   * In `as: 'stream'` mode with `signal: false`, the `total` deadline only
+   * covers up to response headers — a stream that has already been handed to
+   * the caller cannot be retracted by a rejection.
+   */
+  signal?: boolean
 }
 
 /**
@@ -183,7 +203,11 @@ export interface RequestOptions {
   query?: Record<string, string | number | boolean | undefined> | URLSearchParams
   /** Response format — determines the return type. Defaults to buffered. */
   as?: 'json' | 'text' | 'stream'
-  /** Abort signal for cancellation. Combined with the timeout signal via `AbortSignal.any`. */
+  /**
+   * Abort signal for cancellation. Combined with the timeout signal via
+   * `AbortSignal.any` — or passed through untouched when the timeout is
+   * rejection-only (`timeout: {signal: false}`).
+   */
   signal?: AbortSignal
   /** Override the instance-level `httpErrors` setting for this request. */
   httpErrors?: boolean

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,4 +1,4 @@
-import {createRequester, TimeoutError} from 'get-it'
+import {createRequester, type FetchInit, TimeoutError} from 'get-it'
 import {describe, expect, it} from 'vitest'
 import {resolveTimeout} from '../src/createRequester'
 
@@ -34,40 +34,86 @@ describe('TimeoutError', () => {
 
 describe('resolveTimeout', () => {
   it('treats a plain number as total', () => {
-    expect(resolveTimeout(5000)).toEqual({totalMs: 5000, headersMs: undefined})
+    expect(resolveTimeout(5000)).toEqual({totalMs: 5000, headersMs: undefined, attachSignal: true})
   })
 
   it('false and 0 disable total', () => {
-    expect(resolveTimeout(false)).toEqual({totalMs: undefined, headersMs: undefined})
-    expect(resolveTimeout(0)).toEqual({totalMs: undefined, headersMs: undefined})
+    expect(resolveTimeout(false)).toEqual({
+      totalMs: undefined,
+      headersMs: undefined,
+      attachSignal: true,
+    })
+    expect(resolveTimeout(0)).toEqual({
+      totalMs: undefined,
+      headersMs: undefined,
+      attachSignal: true,
+    })
   })
 
   it('defaults total to 120s when unset', () => {
-    expect(resolveTimeout(undefined)).toEqual({totalMs: 120_000, headersMs: undefined})
-    expect(resolveTimeout({headers: 15_000})).toEqual({totalMs: 120_000, headersMs: 15_000})
+    expect(resolveTimeout(undefined)).toEqual({
+      totalMs: 120_000,
+      headersMs: undefined,
+      attachSignal: true,
+    })
+    expect(resolveTimeout({headers: 15_000})).toEqual({
+      totalMs: 120_000,
+      headersMs: 15_000,
+      attachSignal: true,
+    })
   })
 
   it('object form: explicit fields win, falsy disables per field', () => {
     expect(resolveTimeout({total: 30_000, headers: 5000})).toEqual({
       totalMs: 30_000,
       headersMs: 5000,
+      attachSignal: true,
     })
     expect(resolveTimeout({total: false, headers: 5000})).toEqual({
       totalMs: undefined,
       headersMs: 5000,
+      attachSignal: true,
     })
-    expect(resolveTimeout({total: 0})).toEqual({totalMs: undefined, headersMs: undefined})
+    expect(resolveTimeout({total: 0})).toEqual({
+      totalMs: undefined,
+      headersMs: undefined,
+      attachSignal: true,
+    })
     expect(resolveTimeout({total: 30_000, headers: 0})).toEqual({
       totalMs: 30_000,
       headersMs: undefined,
+      attachSignal: true,
     })
   })
 
   it('negative values disable a phase', () => {
-    expect(resolveTimeout(-1)).toEqual({totalMs: undefined, headersMs: undefined})
+    expect(resolveTimeout(-1)).toEqual({
+      totalMs: undefined,
+      headersMs: undefined,
+      attachSignal: true,
+    })
     expect(resolveTimeout({total: -1, headers: -1})).toEqual({
       totalMs: undefined,
       headersMs: undefined,
+      attachSignal: true,
+    })
+  })
+
+  it('signal: false switches to rejection-only mode', () => {
+    expect(resolveTimeout({total: 30_000, signal: false})).toEqual({
+      totalMs: 30_000,
+      headersMs: undefined,
+      attachSignal: false,
+    })
+    expect(resolveTimeout({headers: 5000, signal: false})).toEqual({
+      totalMs: 120_000,
+      headersMs: 5000,
+      attachSignal: false,
+    })
+    expect(resolveTimeout({total: 30_000, signal: true})).toEqual({
+      totalMs: 30_000,
+      headersMs: undefined,
+      attachSignal: true,
     })
   })
 })
@@ -134,6 +180,120 @@ describe('structured timeout behavior', () => {
   it.skipIf('happyDOM' in globalThis)('total covers slow bodies in buffered mode', async () => {
     const request = createRequester({base: baseUrl, timeout: {total: 250}})
     await expect(request('/slow-body?delay=5000')).rejects.toThrow()
+  })
+
+  it('rejection-only mode: total deadline rejects without aborting the fetch', async () => {
+    const request = createRequester({base: baseUrl, timeout: {total: 250, signal: false}})
+    const err = await request('/delay?delay=750').then(
+      () => null,
+      (reason: unknown) => reason,
+    )
+    expect(err).toBeInstanceOf(Error)
+    if (!(err instanceof Error)) throw new Error('expected Error')
+    expect(err.name).toBe('TimeoutError')
+    expect(err.message).toBe('The operation was aborted due to timeout')
+    // The losing fetch keeps running to completion in the background; let it
+    // settle to prove the late response is swallowed (vitest fails the test
+    // on unhandled rejections).
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  })
+
+  it('rejection-only mode: headers deadline rejects with a headers-phase TimeoutError', async () => {
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {headers: 250, total: false, signal: false},
+    })
+    const err = await request('/delay?delay=750').then(
+      () => null,
+      (reason: unknown) => reason,
+    )
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(TimeoutError)
+    if (!(err instanceof TimeoutError)) throw new Error('expected TimeoutError')
+    expect(err.phase).toBe('headers')
+    expect(err.code).toBe('ETIMEDOUT')
+    expect(err.timeoutMs).toBe(250)
+    expect(err.method).toBe('GET')
+    // The losing fetch was not aborted; let its late response (and dangling
+    // body) arrive to prove it is swallowed, not an unhandled rejection.
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  })
+
+  it('rejection-only mode: total covers slow bodies in buffered mode', async () => {
+    const request = createRequester({base: baseUrl, timeout: {total: 250, signal: false}})
+    const err = await request('/slow-body?delay=1000').then(
+      () => null,
+      (reason: unknown) => reason,
+    )
+    expect(err).toBeInstanceOf(Error)
+    if (!(err instanceof Error)) throw new Error('expected Error')
+    expect(err.name).toBe('TimeoutError')
+    // Buffering continues in the background after the race is lost; let the
+    // body finish to prove its settlement is swallowed.
+    await new Promise((resolve) => setTimeout(resolve, 1250))
+  })
+
+  it('rejection-only mode: attaches no timeout-derived signal to the fetch init', async () => {
+    let capturedInit: FetchInit | undefined
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000, headers: 15_000, signal: false},
+      fetch: (_url, init) => {
+        capturedInit = init
+        return Promise.resolve(new Response('spied'))
+      },
+    })
+    const res = await request('/plain-text')
+    expect(res.text()).toBe('spied')
+    expect(capturedInit?.signal).toBeUndefined()
+  })
+
+  it('rejection-only mode: a caller-provided signal passes through untouched and still aborts', async () => {
+    let capturedInit: FetchInit | undefined
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000, signal: false},
+      fetch: (_url, init) => {
+        capturedInit = init
+        const signal = init?.signal
+        // Signal-honoring stand-in for fetch — the real environments differ
+        // in abort support (happy-dom lacks it), and this test is about what
+        // get-it hands to fetch, not the fetch implementation itself.
+        return new Promise<Response>((resolve, reject) => {
+          const timer = setTimeout(() => resolve(new Response('too late')), 5000)
+          signal?.addEventListener('abort', () => {
+            clearTimeout(timer)
+            reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'))
+          })
+        })
+      },
+    })
+    const controller = new AbortController()
+    const rejection = request({url: '/delay?delay=5000', signal: controller.signal}).then(
+      () => null,
+      (reason: unknown) => reason,
+    )
+    controller.abort(new Error('caller aborted'))
+    const err = await rejection
+    expect(capturedInit?.signal).toBe(controller.signal)
+    expect(err).toBeInstanceOf(Error)
+    if (!(err instanceof Error)) throw new Error('expected Error')
+    expect(err.message).toBe('caller aborted')
+  })
+
+  it('rejection-only mode: a response that beats the deadline resolves normally', async () => {
+    const request = createRequester({base: baseUrl, timeout: {total: 250, signal: false}})
+    let error: unknown
+    const res = await request('/plain-text').catch((reason: unknown) => {
+      error = reason
+      return undefined
+    })
+    if (error) throw error
+    if (!res) throw new Error('expected a response')
+    expect(res.text()).toBe('Just some plain text for you to consume')
+    // Let the already-won deadline timer fire; its rejection must stay
+    // swallowed (vitest fails the test on unhandled rejections).
+    await new Promise((resolve) => setTimeout(resolve, 400))
   })
 
   it('{headers, total: false} lets a slow stream complete', async () => {

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -296,6 +296,27 @@ describe('structured timeout behavior', () => {
     await new Promise((resolve) => setTimeout(resolve, 400))
   })
 
+  it('a synchronously-throwing fetch still clears the headers deadline', async () => {
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {headers: 250},
+      fetch: () => {
+        throw new Error('sync throw from custom fetch')
+      },
+    })
+    const err = await request('/plain-text').then(
+      () => null,
+      (reason: unknown) => reason,
+    )
+    expect(err).toBeInstanceOf(Error)
+    if (!(err instanceof Error)) throw new Error('expected Error')
+    expect(err.message).toBe('sync throw from custom fetch')
+    // Wait past the headers deadline: a leaked timer would fire and reject a
+    // promise nothing subscribes to (vitest fails the test on unhandled
+    // rejections).
+    await new Promise((resolve) => setTimeout(resolve, 400))
+  })
+
   it('{headers, total: false} lets a slow stream complete', async () => {
     const request = createRequester({base: baseUrl, timeout: {headers: 1000, total: false}})
     const res = await request({url: '/slow-body?delay=2000', as: 'stream'})


### PR DESCRIPTION
## Motivation

Next.js' patched fetch uses "caller supplied a signal" as its memoization opt-out heuristic, so any signal-carrying request is excluded from React Request Memoization. Since get-it expresses every timeout (including the 120s default) as an abort signal on the fetch init, RSC consumers must currently choose between timeouts and memoization. @sanity/client works around this today with `timeout: false` plus an external `Promise.race` that rejects without aborting (sanity-io/client#1217).

This adds first-class support for that pattern as a consciously degraded escape hatch: `timeout: {total: 30_000, signal: false}` (also valid with `headers`). It is deliberately documented as an escape hatch, not promoted as a general feature - the default abort-based mode remains the right choice everywhere else.

## Semantics

- No timeout-derived abort signal is attached to the fetch init. A caller-provided `signal` in request options is passed through untouched and still aborts.
- When a deadline elapses, the request promise rejects with the same errors as the abort-based path: get-it's `TimeoutError` (`phase: 'headers'`, `code: 'ETIMEDOUT'`) for the headers phase, and the `TimeoutError` DOMException for the total deadline. Keeping the DOMException for `total` also preserves the retry() contract: headers timeouts stay retryable, total timeouts stay non-retryable, same as abort mode.
- The underlying fetch is NOT torn down - it keeps running to completion in the background. Its late settlement is swallowed (never an unhandled rejection), and a late response's dangling body is cancelled to release the connection.
- The `total` deadline covers body download in buffered mode (the race continues while buffering). In `as: 'stream'` mode it only covers up to response headers, since a stream already handed to the caller cannot be retracted by a rejection.
- Deadline timers follow the existing pattern: unref'd so they never hold the process open, and pre-armed with a no-op catch so a timer firing after the race is won stays handled.

## Changes

- `src/createRequester.ts`: `resolveTimeout()` now returns `attachSignal`; `performFetch()` withholds the total deadline from the fetch init in rejection-only mode and races it (plus the headers timer, sans controller) against the fetch; buffering keeps racing the total deadline via a `raceDeadline()` helper.
- `src/types.ts`: `TimeoutOptions.signal?: boolean` with JSDoc spelling out the trade-off (request keeps running, connection held) and the escape-hatch framing.
- `test/timeout.test.ts`: rejection-shape tests for both phases, fetch-spy assertions that no timeout-derived signal reaches the init and that a caller signal flows through and aborts, fast-response and late-settlement tests guarding against unhandled rejections.
- `README.md`: short "escape hatch" subsection under Timeouts stating plainly that a timed-out request keeps running.

## Test results

All green locally:

- `pnpm test` (node): 473 passed
- happy-dom, vercel-edge, react-server, workerd suites: all passed
- `pnpm typecheck` and `pnpm lint`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core timeout/fetch wiring in `performFetch` with subtle Promise.race and background-fetch behavior; mistakes could cause leaks, wrong errors, or broken cancellation, though behavior is well-tested and default abort mode is unchanged.
> 
> **Overview**
> Adds **`timeout: { signal: false }`** as an escape hatch so **`total`** and **`headers`** deadlines still reject with the same errors as today, but **no timeout-derived `signal`** is put on the fetch init—aimed at Next.js RSC, where any init signal opts out of request memoization.
> 
> **`resolveTimeout`** now exposes **`attachSignal`** (false when `signal: false`). **`performFetch`** skips wiring the total deadline into **`buildFetchArgs`**, races **`rejectAfterTimeout`** / headers timers without abort controllers when appropriate, cancels dangling bodies on late responses, and **`raceDeadline`** keeps the total timer active through body buffering in non-stream mode. Caller **`signal`** is passed through unchanged and still aborts.
> 
> **`TimeoutOptions.signal`** and README document trade-offs (background fetch, stream mode limits). Tests cover rejection shapes, no init signal, caller abort, and unhandled-rejection guards; changeset marks a minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf1532b225e8f81ff0ef728fe6ddd2b71190ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->