### PR TITLE
feat(mock): header presence assertions and name matchers for toHaveHeader

### DIFF
--- a/.changeset/matcher-missing-header.md
+++ b/.changeset/matcher-missing-header.md
@@ -1,0 +1,10 @@
+---
+'get-it': minor
+---
+
+Header presence/absence assertions and name matchers for `toHaveHeader`, stricter `anyValue()`
+
+- `toHaveHeader(name, value)` no longer matches when the header is missing, regardless of the value matcher. Previously a missing header (`null`) was fed into the value matcher, so `toHaveHeader('x-foo', anyValue())` passed even when the header was absent.
+- The `value` argument is now optional: `expect(req).toHaveHeader('x-foo')` asserts the header is present with any value, and `expect(req).not.toHaveHeader('x-foo')` asserts absence.
+- The `name` argument now accepts an asymmetric matcher (get-it's or vitest's), tested against lowercased header names: `toHaveHeader(stringMatching(/^x-sanity-/), 'yes')` matches any header whose name and value both match, and `toHaveHeader(anyValue(), 'abc123')` matches any header with that value.
+- `anyValue()` now matches any value except `null` and `undefined`, mirroring vitest's `expect.anything()`. Tests that used `anyValue()` to match a `null` or `undefined` body or query value need to assert that explicitly instead.

--- a/.changeset/pr-624.md
+++ b/.changeset/pr-624.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': patch
+---
+
+fix(mock): lowercase header names defensively in header matching

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ mock
 - `objectContaining(subset)` - matches an object that contains at least the given keys/values
 - `arrayContaining(items)` - matches an array that contains at least the given items
 - `stringMatching(pattern)` - matches a string against a regex or substring
-- `anyValue()` - matches any value
+- `anyValue()` - matches any value except `null`/`undefined` (same semantics as vitest's `expect.anything()`)
 - `queryContaining(subset)` - matches a query object partially, coercing expected number/boolean values to strings (since query params are always strings)
 
 These implement the `asymmetricMatch` protocol, so vitest's `expect.objectContaining()` and friends work too.
@@ -447,6 +447,9 @@ expect(scriptedBody).toHaveBeenCancelled()
 // Assert on individual recorded requests
 const req = mock.getRequests()[0]
 expect(req).toHaveHeader('authorization', 'Bearer token123')
+expect(req).toHaveHeader('authorization') // presence only, any value
+expect(req).not.toHaveHeader('x-legacy-auth') // absence
+expect(req).toHaveHeader(stringMatching(/^x-sanity-/), 'yes') // matcher for the name
 expect(req).toHaveBody(objectContaining({_type: 'post'}))
 expect(req).toHaveQuery({limit: '10'})
 expect(req).toHaveMethod('POST')

--- a/src/_exports/vitest.ts
+++ b/src/_exports/vitest.ts
@@ -14,7 +14,17 @@ declare module 'vitest' {
     ): void
     toHaveReceivedRequestTimes(method: string, url: string, times: number): void
     toHaveConsumedAllMocks(): void
-    toHaveHeader(name: string, value: unknown): void
+    /**
+     * Assert that the request has a matching header.
+     *
+     * - `toHaveHeader(name)` asserts presence only (`.not` asserts absence)
+     * - `value` may be a string or an asymmetric matcher
+     * - `name` may be an asymmetric matcher, tested against lowercased header names
+     */
+    toHaveHeader(
+      name: string | import('../mock/matchers').AsymmetricMatcher,
+      value?: unknown,
+    ): void
     toHaveBody(expected: unknown): void
     toHaveQuery(expected: unknown): void
     toHaveMethod(expected: string): void

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -152,13 +152,15 @@ function getContentType(headers: Headers): string | null {
 
 /**
  * Build a lowercased-key record of a request's headers for matching.
- * `Headers.forEach` already yields lowercased names.
+ * Spec-compliant `Headers.forEach` already yields lowercased names, but some
+ * implementations (eg happy-dom, see capricorn86/happy-dom#2249) preserve the
+ * original casing — lowercase defensively so matching stays case-insensitive.
  * @internal
  */
 function toHeaderRecord(headers: Headers): Record<string, string> {
   const record: Record<string, string> = {}
   headers.forEach((value, key) => {
-    record[key] = value
+    record[key.toLowerCase()] = value
   })
   return record
 }

--- a/src/mock/matchers.ts
+++ b/src/mock/matchers.ts
@@ -73,13 +73,15 @@ export function deepMatch(expected: unknown, actual: unknown): boolean {
 }
 
 /**
- * Matches any value.
+ * Matches any value except `null` and `undefined`, mirroring the semantics of
+ * vitest's `expect.anything()`. In particular, this means a missing header,
+ * query parameter or body does not match.
  * @public
  */
 export function anyValue(): AsymmetricMatcher {
   return {
-    asymmetricMatch(): boolean {
-      return true
+    asymmetricMatch(actual: unknown): boolean {
+      return actual !== null && actual !== undefined
     },
   }
 }

--- a/src/mock/vitestMatchers.ts
+++ b/src/mock/vitestMatchers.ts
@@ -1,5 +1,5 @@
 import type {MockFetch, MockMatchOptions, RecordedRequest} from './createMockFetch'
-import {deepMatch} from './matchers'
+import {type AsymmetricMatcher, deepMatch, isAsymmetricMatcher} from './matchers'
 import {matchUrl, parseUrl} from './urlMatch'
 import {StreamBody} from './streamBody'
 
@@ -162,7 +162,11 @@ function toHaveConsumedAllMocks(received: unknown): MatcherResult {
 // RecordedRequest matchers
 // ---------------------------------------------------------------------------
 
-function toHaveHeader(received: unknown, name: string, value: unknown): MatcherResult {
+function toHaveHeader(
+  received: unknown,
+  name: string | AsymmetricMatcher,
+  value?: unknown,
+): MatcherResult {
   if (!isRecordedRequest(received)) {
     return {
       pass: false,
@@ -170,15 +174,53 @@ function toHaveHeader(received: unknown, name: string, value: unknown): MatcherR
     }
   }
 
-  const actual = received.headers.get(name)
-  const pass = deepMatch(value, actual)
+  // Omitting `value` asserts presence only. Header values can never be
+  // `undefined`, so an explicit `undefined` is treated the same way.
+  const checkValue = value !== undefined
+
+  if (typeof name === 'string') {
+    const actual = received.headers.get(name)
+    const pass = actual !== null && (!checkValue || deepMatch(value, actual))
+
+    return {
+      pass,
+      message: pass
+        ? () =>
+            checkValue
+              ? `Expected request not to have header "${name}" matching ${String(value)}, but it did`
+              : `Expected request not to have header "${name}", but it was set to ${JSON.stringify(actual)}`
+        : () =>
+            checkValue
+              ? `Expected request to have header "${name}" matching ${String(value)}, but got ${actual === null ? '(not set)' : JSON.stringify(actual)}`
+              : `Expected request to have header "${name}", but it was not set`,
+    }
+  }
+
+  if (!isAsymmetricMatcher(name)) {
+    return {
+      pass: false,
+      message: () => 'Expected header name to be a string or an asymmetric matcher',
+    }
+  }
+
+  // Asymmetric name matchers are tested against lowercased header names,
+  // since that is how `Headers` normalizes them.
+  const matched: string[] = []
+  received.headers.forEach((headerValue, headerName) => {
+    if (name.asymmetricMatch(headerName) && (!checkValue || deepMatch(value, headerValue))) {
+      matched.push(headerName)
+    }
+  })
+  const pass = matched.length > 0
+  const description = checkValue
+    ? `a header with name matching ${String(name)} and value matching ${String(value)}`
+    : `a header with name matching ${String(name)}`
 
   return {
     pass,
     message: pass
-      ? () => `Expected request not to have header "${name}" matching ${String(value)}, but it did`
-      : () =>
-          `Expected request to have header "${name}" matching ${String(value)}, but got ${actual === null ? '(not set)' : JSON.stringify(actual)}`,
+      ? () => `Expected request not to have ${description}, but found: ${matched.join(', ')}`
+      : () => `Expected request to have ${description}, but no header matched`,
   }
 }
 

--- a/src/mock/vitestMatchers.ts
+++ b/src/mock/vitestMatchers.ts
@@ -203,12 +203,15 @@ function toHaveHeader(
     }
   }
 
-  // Asymmetric name matchers are tested against lowercased header names,
-  // since that is how `Headers` normalizes them.
+  // Asymmetric name matchers are tested against lowercased header names.
+  // Lowercased explicitly rather than relying on `Headers` normalization,
+  // since some implementations (e.g. happy-dom) preserve the original casing
+  // in iteration despite the fetch spec requiring lowercase.
   const matched: string[] = []
   received.headers.forEach((headerValue, headerName) => {
-    if (name.asymmetricMatch(headerName) && (!checkValue || deepMatch(value, headerValue))) {
-      matched.push(headerName)
+    const lowerName = headerName.toLowerCase()
+    if (name.asymmetricMatch(lowerName) && (!checkValue || deepMatch(value, headerValue))) {
+      matched.push(lowerName)
     }
   })
   const pass = matched.length > 0

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1,6 +1,6 @@
 import {createRequester} from 'get-it'
 import {retry} from 'get-it/middleware'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {createMockFetch} from '../../src/mock/createMockFetch'
 import {MockFetchError} from '../../src/mock/errors'
@@ -1596,6 +1596,66 @@ describe('createMockFetch', () => {
       })
 
       expect(res.status).toBe(200)
+    })
+
+    it('matches mixed-case request header names in non-lowercasing environments', async () => {
+      // Spec-compliant `Headers` iterate with lowercased names, but happy-dom
+      // preserves the original casing (capricorn86/happy-dom#2249). Running
+      // under `pnpm test:happy-dom`, this exercises that real-world case.
+      const mock = createMockFetch()
+      mock.on('GET', '/x', {headers: {authorization: 'Bearer token'}}).respond({status: 200})
+
+      const res = await mock.fetch('https://api.example.com/x', {
+        method: 'GET',
+        headers: {Authorization: 'Bearer token'},
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    it('matches when the Headers implementation iterates original-case names', async () => {
+      // Minimal Headers-compatible fake that (like happy-dom, see
+      // capricorn86/happy-dom#2249) keeps original header-name casing during
+      // iteration, reproducing the non-conforming behavior in any environment.
+      class CasePreservingHeaders {
+        private entries = new Map<string, {name: string; value: string}>()
+        constructor(init?: CasePreservingHeaders | [string, string][] | Record<string, string>) {
+          if (init instanceof CasePreservingHeaders) {
+            init.forEach((value, name) => this.set(name, value))
+          } else if (Array.isArray(init)) {
+            for (const [name, value] of init) this.set(name, value)
+          } else if (init !== undefined) {
+            for (const name of Object.keys(init)) this.set(name, init[name])
+          }
+        }
+        get(name: string): string | null {
+          return this.entries.get(name.toLowerCase())?.value ?? null
+        }
+        has(name: string): boolean {
+          return this.entries.has(name.toLowerCase())
+        }
+        set(name: string, value: string): void {
+          this.entries.set(name.toLowerCase(), {name, value})
+        }
+        forEach(callback: (value: string, name: string) => void): void {
+          for (const {name, value} of this.entries.values()) callback(value, name)
+        }
+      }
+
+      vi.stubGlobal('Headers', CasePreservingHeaders)
+      try {
+        const mock = createMockFetch()
+        mock.on('GET', '/x', {headers: {authorization: 'Bearer token'}}).respond({status: 200})
+
+        const res = await mock.fetch('https://api.example.com/x', {
+          method: 'GET',
+          headers: {Authorization: 'Bearer token'},
+        })
+
+        expect(res.status).toBe(200)
+      } finally {
+        vi.unstubAllGlobals()
+      }
     })
 
     it('reports a headers diff on mismatch', async () => {

--- a/test/mock/matchers.test.ts
+++ b/test/mock/matchers.test.ts
@@ -67,13 +67,20 @@ describe('deepMatch', () => {
 })
 
 describe('anyValue', () => {
-  it('matches any value', () => {
+  it('matches any value except null and undefined', () => {
     const matcher = anyValue()
     expect(matcher.asymmetricMatch('hello')).toBe(true)
     expect(matcher.asymmetricMatch(42)).toBe(true)
-    expect(matcher.asymmetricMatch(null)).toBe(true)
-    expect(matcher.asymmetricMatch(undefined)).toBe(true)
     expect(matcher.asymmetricMatch({a: 1})).toBe(true)
+    expect(matcher.asymmetricMatch('')).toBe(true)
+    expect(matcher.asymmetricMatch(0)).toBe(true)
+    expect(matcher.asymmetricMatch(false)).toBe(true)
+  })
+
+  it('does not match null or undefined (expect.anything() semantics)', () => {
+    const matcher = anyValue()
+    expect(matcher.asymmetricMatch(null)).toBe(false)
+    expect(matcher.asymmetricMatch(undefined)).toBe(false)
   })
 })
 

--- a/test/mock/vitest-matchers.test.ts
+++ b/test/mock/vitest-matchers.test.ts
@@ -3,8 +3,8 @@ import '../../src/_exports/vitest'
 import {createRequester} from 'get-it'
 import {describe, expect, it} from 'vitest'
 
-import {createMockFetch} from '../../src/mock/createMockFetch'
-import {objectContaining} from '../../src/mock/matchers'
+import {createMockFetch, type RecordedRequest} from '../../src/mock/createMockFetch'
+import {anyValue, objectContaining, stringMatching} from '../../src/mock/matchers'
 
 describe('vitest custom matchers', () => {
   describe('MockFetch matchers', () => {
@@ -155,7 +155,7 @@ describe('vitest custom matchers', () => {
 
   describe('RecordedRequest matchers', () => {
     describe('toHaveHeader', () => {
-      it('matches exact header value', async () => {
+      async function recordRequest(headers?: Record<string, string>): Promise<RecordedRequest> {
         const mock = createMockFetch()
         mock.on('POST', '/api/docs').respond({status: 201, body: {id: '1'}})
 
@@ -165,26 +165,90 @@ describe('vitest custom matchers', () => {
           httpErrors: false,
         })
 
-        await request({url: '/api/docs', method: 'POST', body: {title: 'Hello'}, as: 'json'})
+        await request({
+          url: '/api/docs',
+          method: 'POST',
+          body: {title: 'Hello'},
+          headers,
+          as: 'json',
+        })
 
-        const requests = mock.getRequests()
-        expect(requests[0]).toHaveHeader('content-type', 'application/json')
+        const [recorded] = mock.getRequests()
+        if (!recorded) throw new Error('No request was recorded')
+        return recorded
+      }
+
+      it('matches exact header value', async () => {
+        const recorded = await recordRequest()
+        expect(recorded).toHaveHeader('content-type', 'application/json')
       })
 
       it('matches header with asymmetric matcher', async () => {
-        const mock = createMockFetch()
-        mock.on('POST', '/api/docs').respond({status: 201, body: {id: '1'}})
+        const recorded = await recordRequest()
+        expect(recorded).toHaveHeader('content-type', expect.stringContaining('json'))
+      })
 
-        const request = createRequester({
-          base: 'https://api.example.com',
-          fetch: mock.fetch,
-          httpErrors: false,
-        })
+      it('does not match a missing header, even with anyValue()', async () => {
+        const recorded = await recordRequest()
+        expect(recorded).not.toHaveHeader('x-missing', anyValue())
+        expect(() => {
+          expect(recorded).toHaveHeader('x-missing', anyValue())
+        }).toThrow('not set')
+      })
 
-        await request({url: '/api/docs', method: 'POST', body: {title: 'Hello'}, as: 'json'})
+      it('does not match a missing header with expect.anything()', async () => {
+        const recorded = await recordRequest()
+        expect(recorded).not.toHaveHeader('x-missing', expect.anything())
+      })
 
-        const requests = mock.getRequests()
-        expect(requests[0]).toHaveHeader('content-type', expect.stringContaining('json'))
+      it('asserts header presence when called without a value', async () => {
+        const recorded = await recordRequest({'x-custom-token': 'abc123'})
+        expect(recorded).toHaveHeader('x-custom-token')
+        expect(recorded).toHaveHeader('X-Custom-Token')
+      })
+
+      it('asserts header absence via .not without a value', async () => {
+        const recorded = await recordRequest()
+        expect(recorded).not.toHaveHeader('x-missing')
+        expect(() => {
+          expect(recorded).toHaveHeader('x-missing')
+        }).toThrow('not set')
+      })
+
+      it('fails the negated presence check when the header exists', async () => {
+        const recorded = await recordRequest({'x-custom-token': 'abc123'})
+        expect(() => {
+          expect(recorded).not.toHaveHeader('x-custom-token')
+        }).toThrow('abc123')
+      })
+
+      it('matches header name with an asymmetric matcher', async () => {
+        const recorded = await recordRequest({'x-custom-token': 'abc123'})
+        expect(recorded).toHaveHeader(stringMatching(/^x-custom-/), 'abc123')
+        expect(recorded).toHaveHeader(expect.stringContaining('custom'), 'abc123')
+      })
+
+      it('matches any header name for a given value with anyValue()', async () => {
+        const recorded = await recordRequest({'x-custom-token': 'abc123'})
+        expect(recorded).toHaveHeader(anyValue(), 'abc123')
+        expect(recorded).not.toHaveHeader(anyValue(), 'value-no-header-has')
+      })
+
+      it('matches name matcher without a value (presence of any matching header)', async () => {
+        const recorded = await recordRequest({'x-custom-token': 'abc123'})
+        expect(recorded).toHaveHeader(stringMatching(/^x-custom-/))
+        expect(recorded).not.toHaveHeader(stringMatching(/^x-nothing-/))
+      })
+
+      it('requires both name matcher and value to match the same header', async () => {
+        const recorded = await recordRequest({'x-custom-token': 'abc123'})
+        expect(recorded).not.toHaveHeader(stringMatching(/^x-custom-/), 'application/json')
+      })
+
+      it('matches asymmetric header names against lowercased names', async () => {
+        const recorded = await recordRequest({'X-Custom-Token': 'abc123'})
+        expect(recorded).toHaveHeader(stringMatching(/^x-custom-token$/), 'abc123')
+        expect(recorded).not.toHaveHeader(stringMatching(/^X-Custom-Token$/), 'abc123')
       })
     })
 


### PR DESCRIPTION
## Problem

`expect(req).toHaveHeader('x-foo', anyValue())` passed even when the header was missing: `headers.get()` returns `null` for absent headers, and that `null` was fed straight into the value matcher, which `anyValue()` happily matched. As a consequence the negated form could never express header absence.

## Changes

- **Presence gate**: `toHaveHeader(name, value)` never matches a missing header, regardless of the value matcher. Failure messages distinguish "not set" from a mismatched value.
- **Optional value argument**: `expect(req).toHaveHeader('x-foo')` asserts presence with any value, and `expect(req).not.toHaveHeader('x-foo')` asserts absence.
- **Asymmetric matchers for the header name**: `toHaveHeader(stringMatching(/^x-sanity-/), 'yes')` matches any header whose name and value both match, and `toHaveHeader(anyValue(), 'abc123')` matches any header with that value. Both get-it's matchers and vitest's built-ins work. Name matchers run against lowercased header names, since HTTP header names are case-insensitive.
- **`anyValue()` matches vitest `expect.anything()` semantics**: it no longer matches `null`/`undefined`. This is what makes the presence gate compose cleanly, and aligns with the ecosystem convention.

## happy-dom header casing (folds in #624)

happy-dom's `Headers` preserves original name casing during iteration despite the fetch spec requiring lowercase (capricorn86/happy-dom#2249). Two defensive fixes so the mock does not rely on spec-compliant normalization:

- The new asymmetric name matching in `toHaveHeader` lowercases names explicitly before applying the matcher
- `toHeaderRecord` in `createMockFetch` lowercases keys when building the header record for handler constraints (cherry-picked from #624, which this PR supersedes)

## Notes

- The `anyValue()` change is a behavior change: tests that used it to match a `null`/`undefined` body or query value need to assert that explicitly instead. Changeset is marked minor with a migration note.
- The value side of `toHaveHeader` already supported asymmetric matchers; the name side is new.

## Test plan

- New unit tests for `anyValue()` null/undefined rejection
- New `toHaveHeader` tests: missing-header gate (with both `anyValue()` and `expect.anything()`), presence/absence without a value, name matchers (get-it and vitest variants), name+value must match the same header, lowercased name normalization
- Regression tests from #624: mixed-case `Authorization` header against a lowercase-constrained handler, plus a stubbed case-preserving `Headers` fake so the regression is guarded in the default Node run
- Full suite passes on Node (479) and happy-dom (438 passed, 22 skipped); typecheck and lint clean