### PR TITLE
fix: replace deprecated url.parse (DEP0169) with WHATWG URL-based shim

### DIFF
--- a/.changeset/pr-634.md
+++ b/.changeset/pr-634.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': patch
+---
+
+fix: replace deprecated url.parse (DEP0169) with WHATWG URL-based shim

--- a/src/request/node-request.ts
+++ b/src/request/node-request.ts
@@ -5,11 +5,11 @@ import http from 'http'
 import https from 'https'
 import qs from 'querystring'
 import {Readable, type Stream} from 'stream'
-import url from 'url'
 
 import type {RequestAdapter} from '../types'
 import {lowerCaseHeaders} from '../util/lowerCaseHeaders'
 import {progressStream} from '../util/progress-stream'
+import {parseUri} from './node/parseUri'
 import {getProxyOptions, rewriteUriForProxy} from './node/proxy'
 import {concat} from './node/simpleConcat'
 import {timedOut} from './node/timedOut'
@@ -46,7 +46,7 @@ const reduceResponse = (
 
 export const httpRequester: HttpRequest = (context, cb) => {
   const {options} = context
-  const uri = Object.assign({}, url.parse(options.url))
+  const uri = Object.assign({}, parseUri(options.url))
 
   if (typeof fetch === 'function' && options.fetch) {
     const controller = new AbortController()

--- a/src/request/node/parseUri.ts
+++ b/src/request/node/parseUri.ts
@@ -14,8 +14,17 @@ import {format, type UrlWithStringQuery} from 'url'
  *   `http://user@x`), and which `Basic` credentials require
  * - explicitly written default ports (`http://x:80`) are kept in `port`/`host`
  * - `hostname` has no brackets around IPv6 addresses
+ * - the characters `url.parse` auto-escaped but WHATWG leaves literal (see
+ *   `AUTO_ESCAPE`) stay escaped, since `path` goes out on the wire as-is
  * - relative/unparseable input returns the "everything null except path parts"
  *   shape instead of throwing
+ *
+ * Deliberate deviations, where WHATWG is more correct and matching legacy would
+ * mean re-implementing its path parser against the raw string:
+ * - `.`/`..` path segments are resolved (`/a/../b` -> `/b`), which is what the
+ *   fetch and xhr adapters already do, since they hand the URL to the platform
+ * - non-ASCII path/query characters are percent-encoded as UTF-8 instead of
+ *   being passed through as raw bytes
  */
 export function parseUri(uri: string): UrlWithStringQuery {
   let parsed: URL
@@ -39,8 +48,8 @@ export function parseUri(uri: string): UrlWithStringQuery {
   const port = parsed.port || recoverExplicitPort(authority)
   const host = parsed.host ? `${parsed.host}${parsed.port || !port ? '' : `:${port}`}` : null
 
-  const search = parsed.search || null
-  const pathname = parsed.pathname || null
+  const search = parsed.search ? autoEscape(parsed.search) : null
+  const pathname = parsed.pathname ? autoEscape(parsed.pathname) : null
   const path = pathname === null && search === null ? null : `${pathname || ''}${search || ''}`
 
   return withHref({
@@ -50,7 +59,7 @@ export function parseUri(uri: string): UrlWithStringQuery {
     host,
     port: port || null,
     hostname: hostname || null,
-    hash: parsed.hash || null,
+    hash: parsed.hash ? autoEscape(parsed.hash) : null,
     search,
     query: search ? search.slice(1) : null,
     pathname,
@@ -63,6 +72,21 @@ export function parseUri(uri: string): UrlWithStringQuery {
 // is exactly what the non-deprecated `url.format()` produces
 function withHref(parts: Omit<UrlWithStringQuery, 'href'>): UrlWithStringQuery {
   return {...parts, href: format(parts)}
+}
+
+// The characters `url.parse` percent-escaped, which it did uniformly across the
+// path, query and fragment. Keeping them escaped matters because `path` is handed
+// to `http.request()` verbatim, and a literal `|` or `{` in a request target
+// isn't valid per RFC 3986 - strict servers and proxies reject it.
+//
+// The WHATWG parser escapes most of these already, but *which* ones varies by
+// Node version (`^` in a path is literal on Node 22, escaped on Node 24), so
+// re-escape the whole set rather than just the current gap: it's a no-op for the
+// characters the parser already handled, and doesn't rot when the spec moves.
+const AUTO_ESCAPE = /[ "'<>\\^`{|}]/g
+
+function autoEscape(value: string): string {
+  return value.replace(AUTO_ESCAPE, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`)
 }
 
 function getAuthority(uri: string): string {

--- a/src/request/node/parseUri.ts
+++ b/src/request/node/parseUri.ts
@@ -1,0 +1,96 @@
+import {format, type UrlWithStringQuery} from 'url'
+
+/**
+ * Drop-in replacement for the deprecated `url.parse()` (DEP0169), built on the
+ * WHATWG `URL` parser but returning the legacy `UrlWithStringQuery` shape that
+ * the node request adapter spreads into `http.request()` options and exposes
+ * to `finalizeOptions` middleware.
+ *
+ * Legacy behaviors preserved on purpose:
+ * - `auth` is percent-decoded (throws `URIError` on malformed sequences, like
+ *   `url.parse` did) - the tunnel agent and `http.request()` base64 it verbatim
+ * - explicitly written default ports (`http://x:80`) are kept in `port`/`host`
+ * - `hostname` has no brackets around IPv6 addresses
+ * - relative/unparseable input returns the "everything null except path parts"
+ *   shape instead of throwing
+ */
+export function parseUri(uri: string): UrlWithStringQuery {
+  let parsed: URL
+  try {
+    parsed = new URL(uri)
+  } catch {
+    return withHref(parseRelative(uri))
+  }
+
+  const auth =
+    parsed.username || parsed.password
+      ? `${decodeURIComponent(parsed.username)}${
+          parsed.password ? `:${decodeURIComponent(parsed.password)}` : ''
+        }`
+      : null
+
+  // Legacy `hostname` has no brackets around IPv6 addresses, WHATWG does
+  const hostname = parsed.hostname.startsWith('[') ? parsed.hostname.slice(1, -1) : parsed.hostname
+
+  // WHATWG strips explicitly written default ports (`http://x:80`) - recover
+  // them, since the proxy/tunnel code connects to whatever `port` says
+  const port = parsed.port || recoverExplicitPort(uri)
+  const host = parsed.host ? `${parsed.host}${parsed.port || !port ? '' : `:${port}`}` : null
+
+  const search = parsed.search || null
+  const pathname = parsed.pathname || null
+  const path = pathname === null && search === null ? null : `${pathname || ''}${search || ''}`
+
+  return withHref({
+    protocol: parsed.protocol,
+    slashes: parsed.href.startsWith(`${parsed.protocol}//`) || null,
+    auth,
+    host,
+    port: port || null,
+    hostname: hostname || null,
+    hash: parsed.hash || null,
+    search,
+    query: search ? search.slice(1) : null,
+    pathname,
+    path,
+  })
+}
+
+// Legacy `href` is the re-serialization of the parsed parts (e.g. auth is
+// re-encoded with url.format's encoder, recovered ports are included), which
+// is exactly what the non-deprecated `url.format()` produces
+function withHref(parts: Omit<UrlWithStringQuery, 'href'>): UrlWithStringQuery {
+  return {...parts, href: format(parts)}
+}
+
+function recoverExplicitPort(uri: string): string {
+  const authority = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]*)/.exec(uri.trim())
+  if (!authority) {
+    return ''
+  }
+  const hostPart = authority[1].slice(authority[1].lastIndexOf('@') + 1)
+  const port = /:(\d+)$/.exec(hostPart)
+  return port ? port[1] : ''
+}
+
+function parseRelative(uri: string): Omit<UrlWithStringQuery, 'href'> {
+  const hashIndex = uri.indexOf('#')
+  const beforeHash = hashIndex === -1 ? uri : uri.slice(0, hashIndex)
+  const searchIndex = beforeHash.indexOf('?')
+  const search = searchIndex === -1 ? null : beforeHash.slice(searchIndex)
+  const pathname = (searchIndex === -1 ? beforeHash : beforeHash.slice(0, searchIndex)) || null
+
+  return {
+    protocol: null,
+    slashes: null,
+    auth: null,
+    host: null,
+    port: null,
+    hostname: null,
+    hash: hashIndex === -1 ? null : uri.slice(hashIndex),
+    search,
+    query: search ? search.slice(1) : null,
+    pathname,
+    path: beforeHash || null,
+  }
+}

--- a/src/request/node/parseUri.ts
+++ b/src/request/node/parseUri.ts
@@ -16,8 +16,8 @@ import {format, type UrlWithStringQuery} from 'url'
  * - `hostname` has no brackets around IPv6 addresses
  * - the characters `url.parse` auto-escaped but WHATWG leaves literal (see
  *   `AUTO_ESCAPE`) stay escaped, since `path` goes out on the wire as-is
- * - relative/unparseable input returns the "everything null except path parts"
- *   shape instead of throwing
+ * - relative input returns the "everything null except path parts" shape
+ *   instead of throwing (but a *malformed absolute* URL throws - see below)
  *
  * Deliberate deviations, where WHATWG is more correct and matching legacy would
  * mean re-implementing its path parser against the raw string:
@@ -25,12 +25,25 @@ import {format, type UrlWithStringQuery} from 'url'
  *   fetch and xhr adapters already do, since they hand the URL to the platform
  * - non-ASCII path/query characters are percent-encoded as UTF-8 instead of
  *   being passed through as raw bytes
+ * - a malformed authority (`http://x:99999`, `http://user:p/w@x`) throws rather
+ *   than reporting legacy's guesswork (it read those as host `x` and host
+ *   `user`), because the alternative is a request to the wrong host
  */
 export function parseUri(uri: string): UrlWithStringQuery {
   let parsed: URL
   try {
     parsed = new URL(uri)
-  } catch {
+  } catch (err) {
+    // Only genuinely relative input gets the lenient fallback. An absolute URL
+    // the parser rejected (invalid port, malformed IPv6) must not fall through
+    // to it: `host` would be null, which `http.request()` defaults to localhost
+    // while putting the whole URI in `path` - silently sending a request meant
+    // for a remote host to the local machine. Legacy failed on the bad
+    // authority instead, so throw, as `url.parse` itself did for some of these
+    if (HAS_AUTHORITY.test(uri.trim())) {
+      throw err
+    }
+
     return withHref(parseRelative(uri))
   }
 
@@ -88,6 +101,9 @@ const AUTO_ESCAPE = /[ "'<>\\^`{|}]/g
 function autoEscape(value: string): string {
   return value.replace(AUTO_ESCAPE, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`)
 }
+
+// `scheme://` - i.e. the input carries an authority, so it isn't relative
+const HAS_AUTHORITY = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//
 
 function getAuthority(uri: string): string {
   const match = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]*)/.exec(uri.trim())

--- a/src/request/node/parseUri.ts
+++ b/src/request/node/parseUri.ts
@@ -9,6 +9,9 @@ import {format, type UrlWithStringQuery} from 'url'
  * Legacy behaviors preserved on purpose:
  * - `auth` is percent-decoded (throws `URIError` on malformed sequences, like
  *   `url.parse` did) - the tunnel agent and `http.request()` base64 it verbatim
+ * - an explicitly written empty password (`http://user:@x`) keeps its colon,
+ *   which WHATWG can't express (it reports the same empty `password` as
+ *   `http://user@x`), and which `Basic` credentials require
  * - explicitly written default ports (`http://x:80`) are kept in `port`/`host`
  * - `hostname` has no brackets around IPv6 addresses
  * - relative/unparseable input returns the "everything null except path parts"
@@ -22,19 +25,18 @@ export function parseUri(uri: string): UrlWithStringQuery {
     return withHref(parseRelative(uri))
   }
 
-  const auth =
-    parsed.username || parsed.password
-      ? `${decodeURIComponent(parsed.username)}${
-          parsed.password ? `:${decodeURIComponent(parsed.password)}` : ''
-        }`
-      : null
+  // The raw authority is the only place some legacy details survive, since
+  // WHATWG normalizes them away before we get to look at the parsed parts
+  const authority = getAuthority(uri)
+
+  const auth = recoverAuth(authority, parsed)
 
   // Legacy `hostname` has no brackets around IPv6 addresses, WHATWG does
   const hostname = parsed.hostname.startsWith('[') ? parsed.hostname.slice(1, -1) : parsed.hostname
 
   // WHATWG strips explicitly written default ports (`http://x:80`) - recover
   // them, since the proxy/tunnel code connects to whatever `port` says
-  const port = parsed.port || recoverExplicitPort(uri)
+  const port = parsed.port || recoverExplicitPort(authority)
   const host = parsed.host ? `${parsed.host}${parsed.port || !port ? '' : `:${port}`}` : null
 
   const search = parsed.search || null
@@ -63,12 +65,29 @@ function withHref(parts: Omit<UrlWithStringQuery, 'href'>): UrlWithStringQuery {
   return {...parts, href: format(parts)}
 }
 
-function recoverExplicitPort(uri: string): string {
-  const authority = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]*)/.exec(uri.trim())
-  if (!authority) {
-    return ''
+function getAuthority(uri: string): string {
+  const match = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]*)/.exec(uri.trim())
+  return match ? match[1] : ''
+}
+
+// Legacy `auth` is the userinfo verbatim (percent-decoded), so it distinguishes
+// `user` from `user:` - WHATWG doesn't, so the separator has to come from the
+// raw userinfo. Like legacy, the *last* `@` ends it, so an unencoded `@` in the
+// password (`user:p@ss@host`) is handled the same way.
+function recoverAuth(authority: string, parsed: URL): string | null {
+  const at = authority.lastIndexOf('@')
+  if (at === -1) {
+    return null
   }
-  const hostPart = authority[1].slice(authority[1].lastIndexOf('@') + 1)
+
+  const username = decodeURIComponent(parsed.username)
+  return authority.slice(0, at).includes(':')
+    ? `${username}:${decodeURIComponent(parsed.password)}`
+    : username
+}
+
+function recoverExplicitPort(authority: string): string {
+  const hostPart = authority.slice(authority.lastIndexOf('@') + 1)
   const port = /:(\d+)$/.exec(hostPart)
   return port ? port[1] : ''
 }

--- a/src/request/node/proxy.ts
+++ b/src/request/node/proxy.ts
@@ -6,6 +6,7 @@
 import url, {type UrlWithStringQuery} from 'url'
 
 import type {ProxyOptions, RequestOptions} from '../../types'
+import {parseUri} from './parseUri'
 
 function formatHostname(hostname: string) {
   // canonicalize the hostname, so that 'oogle.com' won't match 'google.com'
@@ -123,7 +124,7 @@ export function rewriteUriForProxy(
 
 export function getProxyOptions(options: RequestOptions): UrlWithStringQuery | ProxyOptions | null {
   const proxy =
-    typeof options.proxy === 'undefined' ? getProxyFromUri(url.parse(options.url)) : options.proxy
+    typeof options.proxy === 'undefined' ? getProxyFromUri(parseUri(options.url)) : options.proxy
 
-  return typeof proxy === 'string' ? url.parse(proxy) : proxy || null
+  return typeof proxy === 'string' ? parseUri(proxy) : proxy || null
 }

--- a/src/request/node/tunnel.ts
+++ b/src/request/node/tunnel.ts
@@ -4,7 +4,8 @@
  * Apache License 2.0
  */
 import * as tunnel from 'tunnel-agent'
-import url from 'url'
+
+import {parseUri} from './parseUri'
 
 const uriParts = [
   'protocol',
@@ -56,7 +57,7 @@ export function shouldEnable(options: any) {
   }
 
   // If the destination is HTTPS, tunnel.
-  const uri = url.parse(options.url)
+  const uri = parseUri(options.url)
   if (uri.protocol === 'https:') {
     return true
   }

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -31,6 +31,19 @@ describe('basics', {timeout: 15000}, () => {
     expect(body.headers).toMatchObject({authorization: 'Basic dXNlcjpwQHNz'})
   })
 
+  // Token-as-username URLs (`token:@host`) must keep the trailing colon, or the
+  // `Authorization` value isn't valid `Basic` credentials
+  it.skipIf(adapter !== 'node')(
+    'should keep an explicitly empty password in basic auth',
+    async () => {
+      const request = getIt([jsonResponse(), debugRequest])
+      const req = request({url: `${baseUrlPrefix.replace('://', '://token:@')}/debug`})
+      const body: any = await promiseRequest(req).then((res: any) => res.body)
+      // base64 of `token:`, not of `token`
+      expect(body.headers).toMatchObject({authorization: 'Basic dG9rZW46'})
+    },
+  )
+
   it('should be able to request a basic, plain-text file', async () => {
     const body = 'Just some plain text for you to consume'
     const request = getIt([baseUrl, debugRequest])

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -22,6 +22,15 @@ describe('basics', {timeout: 15000}, () => {
     return expect(() => request({url: 'heisann'})).to.throw(/valid URL/)
   })
 
+  // The fetch spec forbids credentials in request URLs, so this only works on the node adapter
+  it.skipIf(adapter !== 'node')('should send percent-decoded basic auth from the URL', async () => {
+    const request = getIt([jsonResponse(), debugRequest])
+    const req = request({url: `${baseUrlPrefix.replace('://', '://user:p%40ss@')}/debug`})
+    const body: any = await promiseRequest(req).then((res: any) => res.body)
+    // base64 of the decoded credentials, `user:p@ss`
+    expect(body.headers).toMatchObject({authorization: 'Basic dXNlcjpwQHNz'})
+  })
+
   it('should be able to request a basic, plain-text file', async () => {
     const body = 'Just some plain text for you to consume'
     const request = getIt([baseUrl, debugRequest])

--- a/test/helpers/proxy.ts
+++ b/test/helpers/proxy.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import http from 'node:http'
 import https from 'node:https'
 import path from 'node:path'
-import url from 'node:url'
 
 const httpsServerOptions = {
   key: fs.readFileSync(path.join(__dirname, '..', 'certs', 'server', 'key.pem')),
@@ -18,11 +17,11 @@ export function createProxyServer(proto: 'http' | 'https' = 'http') {
     const protoPort = isHttp ? httpPort : httpsPort
     const protoOpts = isHttp ? {} : httpsServerOptions
     const requestHandler = (request: any, response: any) => {
-      const parsed = url.parse(request.url)
+      const parsed = new URL(request.url)
       const opts = {
         host: parsed.hostname,
         port: parsed.port,
-        path: parsed.path,
+        path: `${parsed.pathname}${parsed.search}`,
         rejectUnauthorized: false,
       }
 

--- a/test/helpers/server.ts
+++ b/test/helpers/server.ts
@@ -3,7 +3,6 @@ import http from 'node:http'
 import https from 'node:https'
 import path from 'node:path'
 import qs from 'node:querystring'
-import url from 'node:url'
 import zlib from 'node:zlib'
 
 import {concat} from '../../src/request/node/simpleConcat'
@@ -29,7 +28,8 @@ const requestCounters: Record<string, number> = {}
 function getResponseHandler(proto = 'http'): any {
   const isSecure = proto === 'https'
   return (req: any, res: any, next: any) => {
-    const parts = url.parse(req.url, true)
+    const parsedUrl = new URL(req.url, 'http://localhost')
+    const parts = {pathname: parsedUrl.pathname, query: qs.parse(parsedUrl.search.slice(1))}
     const num = Number(parts.query['n'])
     const atMax = num >= 10
     const uuid: any = parts.query['uuid']

--- a/test/parseUri.test.ts
+++ b/test/parseUri.test.ts
@@ -217,6 +217,96 @@ describe('parseUri', () => {
         href: 'http://user@example.com/',
       },
     ],
+    // an explicitly written empty password must keep its colon: `Basic`
+    // credentials require the separator, and WHATWG reports the same empty
+    // `password` here as it does for `http://user@example.com/` above
+    [
+      'http://user:@example.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://user:@example.com/',
+      },
+    ],
+    [
+      'http://:pass@example.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: ':pass',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://:pass@example.com/',
+      },
+    ],
+    [
+      'http://@example.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: '',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://example.com/',
+      },
+    ],
+    [
+      'http://:@example.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: ':',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://:@example.com/',
+      },
+    ],
+    // legacy ends the userinfo at the *last* `@`, so an unencoded `@` in the
+    // password belongs to the password
+    [
+      'http://user:p@ss@example.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:p@ss',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://user:p%40ss@example.com/',
+      },
+    ],
   ]
 
   it.each(cases)('parses %s like legacy url.parse', (input, expected) => {

--- a/test/parseUri.test.ts
+++ b/test/parseUri.test.ts
@@ -386,8 +386,8 @@ describe('parseUri', () => {
       // dot segments are resolved and non-ASCII is percent-encoded, on purpose
       /\/\.\.?(\/|$)|[^ -~]/.test(uri) ||
       // `new URL()` rejects these (a `#`, `/`, `?` or `\` ends the authority
-      // early), so they take the null-shape fallback. Legacy's answer is junk
-      // anyway: it reports `host: 'user'` with `path: '/:p'`
+      // early), so parseUri throws. Legacy instead guessed, reporting
+      // `host: 'user'` with `path: '/:p'` - a host nobody asked for
       /^http:\/\/user:p[#/?\\]w@/.test(uri) ||
       // WHATWG drops an empty query/fragment delimiter, legacy kept `?` / `#`.
       // No server routes on an empty query, so this stays as-is
@@ -421,6 +421,35 @@ describe('parseUri', () => {
     // segments, and legacy passed non-ASCII through as raw bytes
     expect(parseUri('http://example.com/a/../b').path).toBe('/b')
     expect(parseUri('http://example.com/ä').path).toBe('/%C3%A4')
+  })
+
+  // A malformed absolute URL must never reach the relative fallback: that shape
+  // has `host: null`, which `http.request()` defaults to localhost while putting
+  // the whole URI in `path`, quietly sending the request to the local machine
+  it.each([
+    'http://x.com:99999/a',
+    'http://x.com:abc/a',
+    'http://x.com:-1/a',
+    'http://[::1/a',
+    'http://user:p/w@x.com/p',
+    'https://exa mple.com/a',
+    'http://%zz.com/a',
+  ])('throws on the malformed absolute URL %s rather than falling back', (input) => {
+    expect(() => parseUri(input)).toThrow()
+  })
+
+  it('never reports a null host for input carrying an authority', () => {
+    // The property that keeps a request from being retargeted to localhost
+    const inputs = ['http://x.com:99999/a', 'http://[::1/a', 'http://user:p/w@x.com/p']
+    for (const input of inputs) {
+      let parsed
+      try {
+        parsed = parseUri(input)
+      } catch {
+        continue // throwing is the intended outcome
+      }
+      expect(parsed.host).not.toBeNull()
+    }
   })
 
   it('does not throw on non-absolute input, mimicking legacy fallback shape', () => {

--- a/test/parseUri.test.ts
+++ b/test/parseUri.test.ts
@@ -1,0 +1,246 @@
+import {describe, expect, it} from 'vitest'
+
+import {parseUri} from '../src/request/node/parseUri'
+
+// `parseUri` replaces the deprecated `url.parse()` (DEP0169) but must keep
+// returning the exact same legacy `UrlWithStringQuery` shape, since the object
+// is spread into `http.request()` options and exposed to `finalizeOptions`
+// middleware. The expected objects below are captured verbatim from
+// `url.parse()` output.
+describe('parseUri', () => {
+  const cases: [string, Record<string, unknown>][] = [
+    [
+      'http://example.com',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://example.com/',
+      },
+    ],
+    [
+      'https://example.com/path/to/thing?foo=bar&baz=1#section',
+      {
+        protocol: 'https:',
+        slashes: true,
+        auth: null,
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: '#section',
+        search: '?foo=bar&baz=1',
+        query: 'foo=bar&baz=1',
+        pathname: '/path/to/thing',
+        path: '/path/to/thing?foo=bar&baz=1',
+        href: 'https://example.com/path/to/thing?foo=bar&baz=1#section',
+      },
+    ],
+    [
+      'http://user:pass@example.com:8080/x?y=1',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pass',
+        host: 'example.com:8080',
+        port: '8080',
+        hostname: 'example.com',
+        hash: null,
+        search: '?y=1',
+        query: 'y=1',
+        pathname: '/x',
+        path: '/x?y=1',
+        href: 'http://user:pass@example.com:8080/x?y=1',
+      },
+    ],
+    [
+      'http://localhost:3000',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'localhost:3000',
+        port: '3000',
+        hostname: 'localhost',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://localhost:3000/',
+      },
+    ],
+    [
+      'https://[::1]:8443/ipv6',
+      {
+        protocol: 'https:',
+        slashes: true,
+        auth: null,
+        host: '[::1]:8443',
+        port: '8443',
+        hostname: '::1',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/ipv6',
+        path: '/ipv6',
+        href: 'https://[::1]:8443/ipv6',
+      },
+    ],
+    [
+      'http://example.com/percent%20encoded?q=a%26b',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: '?q=a%26b',
+        query: 'q=a%26b',
+        pathname: '/percent%20encoded',
+        path: '/percent%20encoded?q=a%26b',
+        href: 'http://example.com/percent%20encoded?q=a%26b',
+      },
+    ],
+    // auth must be percent-decoded like legacy url.parse: the tunnel agent and
+    // http.request() base64 it verbatim for (Proxy-)Authorization headers
+    [
+      'http://user:p%40ss@example.com/x',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:p@ss',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/x',
+        path: '/x',
+        href: 'http://user:p%40ss@example.com/x',
+      },
+    ],
+    [
+      'http://user:pa%3Ass@x.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user:pa:ss',
+        host: 'x.com',
+        port: null,
+        hostname: 'x.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://user:pa:ss@x.com/',
+      },
+    ],
+    // explicit default ports must survive: proxy/tunnel code reads uri.port to
+    // decide which port to connect to (WHATWG URL strips them)
+    [
+      'http://proxy.corp:80',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'proxy.corp:80',
+        port: '80',
+        hostname: 'proxy.corp',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://proxy.corp:80/',
+      },
+    ],
+    [
+      'https://proxy.corp:443',
+      {
+        protocol: 'https:',
+        slashes: true,
+        auth: null,
+        host: 'proxy.corp:443',
+        port: '443',
+        hostname: 'proxy.corp',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'https://proxy.corp:443/',
+      },
+    ],
+    [
+      'https://[::1]:443/a',
+      {
+        protocol: 'https:',
+        slashes: true,
+        auth: null,
+        host: '[::1]:443',
+        port: '443',
+        hostname: '::1',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/a',
+        path: '/a',
+        href: 'https://[::1]:443/a',
+      },
+    ],
+    [
+      'http://user@example.com/',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: 'user',
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/',
+        path: '/',
+        href: 'http://user@example.com/',
+      },
+    ],
+  ]
+
+  it.each(cases)('parses %s like legacy url.parse', (input, expected) => {
+    expect({...parseUri(input)}).toEqual(expected)
+  })
+
+  it('throws URIError on malformed percent-encoding in userinfo, like legacy url.parse', () => {
+    expect(() => parseUri('http://us%er@x.com/')).toThrow(URIError)
+  })
+
+  it('does not throw on non-absolute input, mimicking legacy fallback shape', () => {
+    expect({...parseUri('/just/a/path?q=1')}).toEqual({
+      protocol: null,
+      slashes: null,
+      auth: null,
+      host: null,
+      port: null,
+      hostname: null,
+      hash: null,
+      search: '?q=1',
+      query: 'q=1',
+      pathname: '/just/a/path',
+      path: '/just/a/path?q=1',
+      href: '/just/a/path?q=1',
+    })
+  })
+})

--- a/test/parseUri.test.ts
+++ b/test/parseUri.test.ts
@@ -1,3 +1,4 @@
+import url from 'url'
 import {describe, expect, it} from 'vitest'
 
 import {parseUri} from '../src/request/node/parseUri'
@@ -307,6 +308,45 @@ describe('parseUri', () => {
         href: 'http://user:p%40ss@example.com/',
       },
     ],
+    // legacy auto-escaped ` "'<>\^`{|}` in the path, query and fragment alike,
+    // and `path` goes out on the wire as-is, so they have to stay escaped. Which
+    // of them the WHATWG parser escapes on its own is Node-version dependent,
+    // which is what the differential sweep below guards
+    [
+      "http://example.com/it's?q=a|b",
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: null,
+        search: '?q=a%7Cb',
+        query: 'q=a%7Cb',
+        pathname: '/it%27s',
+        path: '/it%27s?q=a%7Cb',
+        href: 'http://example.com/it%27s?q=a%7Cb',
+      },
+    ],
+    // a GROQ-shaped query is the realistic case: `|`, `{` and `}` are common
+    [
+      'http://example.com/v1/data/query/prod?query={a}|order(x)^`#f|{x}',
+      {
+        protocol: 'http:',
+        slashes: true,
+        auth: null,
+        host: 'example.com',
+        port: null,
+        hostname: 'example.com',
+        hash: '#f%7C%7Bx%7D',
+        search: '?query=%7Ba%7D%7Corder(x)%5E%60',
+        query: 'query=%7Ba%7D%7Corder(x)%5E%60',
+        pathname: '/v1/data/query/prod',
+        path: '/v1/data/query/prod?query=%7Ba%7D%7Corder(x)%5E%60',
+        href: 'http://example.com/v1/data/query/prod?query=%7Ba%7D%7Corder(x)%5E%60#f%7C%7Bx%7D',
+      },
+    ],
   ]
 
   it.each(cases)('parses %s like legacy url.parse', (input, expected) => {
@@ -315,6 +355,72 @@ describe('parseUri', () => {
 
   it('throws URIError on malformed percent-encoding in userinfo, like legacy url.parse', () => {
     expect(() => parseUri('http://us%er@x.com/')).toThrow(URIError)
+  })
+
+  // The hand-written cases above document the interesting inputs; this sweep is
+  // what actually catches escaping and normalization drift, by diffing every
+  // printable ASCII character in every component against the real `url.parse`
+  it('matches legacy url.parse across a differential sweep', () => {
+    const corpus: string[] = [
+      'http://example.com',
+      'http://example.com/',
+      'http://example.com:8080/a?b=c#d',
+      'http://example.com/a//b',
+      'http://example.com/%7Euser',
+      'http://example.com/%41?q=%42#%43',
+      'http://example.com/a%2e%2e/b',
+      'http://example.com/a?b#c?d',
+    ]
+    for (let code = 0x20; code < 0x7f; code++) {
+      const char = String.fromCharCode(code)
+      corpus.push(
+        `http://example.com/a${char}b`,
+        `http://example.com/p?q=a${char}b`,
+        `http://example.com/p#f${char}g`,
+        `http://user:p${char}w@example.com/p`,
+      )
+    }
+
+    // Inputs the shim knowingly handles differently - see parseUri's doc comment
+    const deviates = (uri: string) =>
+      // dot segments are resolved and non-ASCII is percent-encoded, on purpose
+      /\/\.\.?(\/|$)|[^ -~]/.test(uri) ||
+      // `new URL()` rejects these (a `#`, `/`, `?` or `\` ends the authority
+      // early), so they take the null-shape fallback. Legacy's answer is junk
+      // anyway: it reports `host: 'user'` with `path: '/:p'`
+      /^http:\/\/user:p[#/?\\]w@/.test(uri) ||
+      // WHATWG drops an empty query/fragment delimiter, legacy kept `?` / `#`.
+      // No server routes on an empty query, so this stays as-is
+      /[?#]+$/.test(uri)
+
+    // Key order isn't part of the contract, and a thrown URIError has to match
+    // too (both reject malformed percent-encoding in the userinfo)
+    const snapshot = (parse: (uri: string) => object, uri: string) => {
+      try {
+        const parts = {...parse(uri)}
+        return JSON.stringify(parts, Object.keys(parts).sort())
+      } catch (err) {
+        return `throws ${(err as Error).name}`
+      }
+    }
+
+    const mismatches = corpus
+      .filter((uri) => !deviates(uri))
+      .map((uri) => ({
+        uri,
+        legacy: snapshot(url.parse, uri),
+        actual: snapshot(parseUri, uri),
+      }))
+      .filter(({legacy, actual}) => legacy !== actual)
+
+    expect(mismatches).toEqual([])
+  })
+
+  it('resolves dot segments and encodes non-ASCII, unlike legacy url.parse', () => {
+    // Deliberate deviations: the fetch and xhr adapters already resolve dot
+    // segments, and legacy passed non-ASCII through as raw bytes
+    expect(parseUri('http://example.com/a/../b').path).toBe('/b')
+    expect(parseUri('http://example.com/ä').path).toBe('/%C3%A4')
   })
 
   it('does not throw on non-absolute input, mimicking legacy fallback shape', () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -113,6 +113,19 @@ describe.runIf(environment === 'node')('proxy', {timeout: 15000}, () => {
     })
   })
 
+  it('http: should support percent-encoded HTTP proxy auth from env', async () => {
+    process.env['http_proxy'] = 'http://user:p%40ss@localhost:4000/'
+
+    const request = getIt([baseUrl, debugRequest])
+
+    const res = await promiseRequest(request({url: '/plain-text'}))
+    expect(res).toHaveProperty('headers')
+    expect(res.headers).toMatchObject({
+      // base64 of the decoded credentials, `user:p@ss`
+      'x-proxy-auth': 'Basic dXNlcjpwQHNz',
+    })
+  })
+
   it('http: should use requested hostname as Host header', async () => {
     process.env['http_proxy'] = 'http://localhost:4000/'
 


### PR DESCRIPTION
Node runtime-deprecated `url.parse()` (DEP0169), so v8 consumers see deprecation warnings whenever the node adapter builds a request. The v9+ line on `main` already uses WHATWG URL/fetch, but v8 still calls `url.parse` in the node request, proxy, and tunnel paths.

## What changed

- Added an internal `parseUri()` helper (`src/request/node/parseUri.ts`) that parses with `new URL()` but returns the legacy `UrlWithStringQuery` shape. The object is spread into `http.request()` options and handed to `finalizeOptions` middleware, so keeping the shape identical is what makes this non-breaking. Legacy quirks are preserved: `query` as a string, bracket-less IPv6 hostnames, `slashes`, and no throw on relative/unparseable input (falls back to the same "everything null except path parts" shape `url.parse` produced).
- Swapped the four `url.parse` call sites: `node-request.ts`, `node/proxy.ts` (request URL + proxy string from env), and `node/tunnel.ts`. `url.format()` in `proxy.ts` stays — it's legacy but emits no warning.
- Migrated the test helper servers (`test/helpers/proxy.ts`, `test/helpers/server.ts`) off `url.parse` as well. The server helper keeps `querystring.parse` for the query object because tests rely on duplicate keys parsing to arrays.

Public types (`FinalizeNodeOptionsPayload`, `UrlWithStringQuery` import in `types.ts`) are untouched.

## Behavior notes

Two known differences from `url.parse`, both benign for our call sites:

- WHATWG strips explicit default ports (`http://x:80` → `port: null`). The proxy/host-header logic already falls back to 80/443, so results are unchanged.
- Garbage input like `localhost:8080` parses slightly differently, but every consumer checks `protocol === 'http:'/'https:'` first and rejects it either way.

## Testing

- `test/parseUri.test.ts` asserts the helper output deep-equals captured `url.parse()` output for auth, custom ports, IPv6, percent-encoding, fragments, and relative-path fallback (written first, watched fail).
- Full suite: 192 passed, typecheck and lint clean.
- Ran the suite under `NODE_OPTIONS=--pending-deprecation` (forces DEP0169 to emit): zero occurrences, where before the change it warned from both `src` and the test proxy helper.

A separate `DEP0111` (`process.binding`) warning from the `tunnel-agent` dependency remains; replacing that package is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> URL parsing drives host, path, and Basic/proxy auth for all node requests; regressions could misroute traffic or break credentials, though behavior is heavily tested and malformed absolute URLs are rejected instead of silently defaulting to localhost.
> 
> **Overview**
> Removes Node **DEP0169** warnings by swapping **`url.parse()`** for a new **`parseUri()`** helper on the node adapter’s request, proxy, and tunnel paths.
> 
> **`parseUri()`** uses **`new URL()`** but still returns the legacy **`UrlWithStringQuery`** object (spread into **`http.request()`** and **`finalizeOptions`**). It keeps important **`url.parse`** behavior: percent-decoded **`auth`**, trailing colon for empty passwords, explicit default ports, bracket-less IPv6 hostnames, legacy-style path/query escaping, and a non-throwing relative-URL fallback. Malformed absolute URLs **throw** instead of falling back to a **`host: null`** shape that could hit localhost.
> 
> Test helpers move to WHATWG **`URL`** as well. Coverage adds **`test/parseUri.test.ts`** (parity vs legacy, differential sweep), node-only URL basic-auth checks, and percent-encoded proxy auth from env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e934415a3cc7534bdceaf3f016385141f89bd1b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->