### PR TITLE
fix(ci): skip changeset generation when base branch lacks the script

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -46,7 +46,13 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: node base-scripts/.github/scripts/generate-changeset.mjs
+        run: |
+          if [ ! -f base-scripts/.github/scripts/generate-changeset.mjs ]; then
+            echo "Base branch '${{ github.event.pull_request.base.ref }}' has no generate-changeset script, skipping"
+            echo "action=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node base-scripts/.github/scripts/generate-changeset.mjs
 
       - name: Checkout PR branch
         if: steps.analyze.outputs.action == 'write' || steps.analyze.outputs.action == 'remove'


### PR DESCRIPTION
## Why

The "Generate changeset from PR" workflow checks out `.github/scripts` from the PR's **base** branch, then runs `generate-changeset.mjs` from it. For PRs targeting branches that predate the script (currently `v8`, see #636), the file doesn't exist and the job fails with `MODULE_NOT_FOUND`.

## What

Guard the analyze step: if the base branch has no `generate-changeset.mjs`, log and skip instead of failing. The follow-up steps already gate on `action == 'write' || action == 'remove'`, so they stay skipped.

#636 also adds the script to `v8` itself, so future PRs targeting `v8` will get real changeset generation - but that can't take effect for the setup PR itself, since the script is read from the base ref pre-merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only guard with no product code impact; downstream steps were already gated on write/remove.
> 
> **Overview**
> The **Generate changeset from PR** workflow no longer fails when the PR’s **base** branch doesn’t include `generate-changeset.mjs` (e.g. older release branches like `v8`).
> 
> The analyze step now checks for `base-scripts/.github/scripts/generate-changeset.mjs` after the sparse checkout. If it’s missing, it logs which base ref was used, sets `action=skip` on the step output, and exits successfully instead of running Node and hitting `MODULE_NOT_FOUND`. Checkout/write/remove steps are unchanged and still only run when `action` is `write` or `remove`, so a skip leaves the job green with no changeset work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5359178fd87d3ee26415617de8891dbeffb7db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->