### PR TITLE
ci: publish preview releases with pkg.pr.new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,32 @@
+name: Publish Pull Requests with pkg.pr.new
+
+permissions:
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: >
+      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview')
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          cache: pnpm
+          node-version: lts/*
+      - name: Install project dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build package
+        run: pnpm run build
+      - name: Publish to pkg.pr.new
+        run: npx pkg-pr-new publish --compact --no-template


### PR DESCRIPTION
### Description

Adds a GitHub Actions workflow that publishes preview releases to [pkg.pr.new](https://pkg.pr.new/) for pull requests labeled `trigger: preview`, mirroring the setup in [sanity-io/client](https://github.com/sanity-io/client/blob/main/.github/workflows/pkg-pr-new.yml).

- Triggers on `opened`, `synchronize` and `labeled` events, but only runs when the PR carries the `trigger: preview` label (already exists on this repo)
- Uses pnpm with the same action versions and caching as `ci.yml`
- Publishes with `--compact` (the `repository` field in `package.json` is already correct here) and `--no-template`
- Concurrency group cancels in-flight preview builds on rapid pushes

### What to review

The workflow file itself. To verify end to end, add the `trigger: preview` label to this PR - the pkg.pr.new app is installed, so it should comment with an install URL like `npm i https://pkg.pr.new/get-it@<pr>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no runtime or application code changes; preview publishes are opt-in via label.
> 
> **Overview**
> Adds **`.github/workflows/pkg-pr-new.yml`**, a new workflow that publishes installable preview builds to [pkg.pr.new](https://pkg.pr.new/) when a PR has the **`trigger: preview`** label.
> 
> It listens on PR **`opened`**, **`synchronize`**, and **`labeled`**, grants **`pull-requests: write`** (for pkg.pr.new comments), and uses a **concurrency** group with **`cancel-in-progress`** so rapid pushes cancel stale preview runs. The job reuses the same **pnpm / Node LTS / frozen lockfile** pattern as **`ci.yml`**, runs **`pnpm run build`**, then **`npx pkg-pr-new publish --compact --no-template`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d65850d27747bd30b4777498833681a9bd6ed92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->