### PR TITLE
fix: clear total-deadline timers once the request settles

### DIFF
--- a/.changeset/pr-640.md
+++ b/.changeset/pr-640.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': patch
+---
+
+fix: clear total-deadline timers once the request settles

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -75,13 +75,14 @@ export function createRequester(
     url: string
     method: string
     totalDeadline: Promise<never> | undefined
+    clearDeadline: () => void
   }> {
     const {totalMs, headersMs, attachSignal} = resolveTimeout(
       opts.timeout !== undefined ? opts.timeout : instanceTimeout,
     )
     // In rejection-only mode the total deadline must not become a fetch-init
     // signal, so it is withheld from buildFetchArgs and raced below instead.
-    const {url, init} = buildFetchArgs(
+    const {url, init, clearTotalTimer} = buildFetchArgs(
       opts,
       attachSignal ? totalMs : undefined,
       instanceCredentials,
@@ -95,16 +96,31 @@ export function createRequester(
     // background — the caller opted out of teardown (e.g. so Next.js RSC
     // request memoization stays enabled) — and its late settlement is
     // swallowed in the catch block below.
-    const totalDeadline =
+    const totalTimeout =
       !attachSignal && totalMs !== undefined
         ? rejectAfterTimeout(
             totalMs,
             new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
           )
         : undefined
+    const totalDeadline = totalTimeout?.deadline
+
+    // Releases the total-deadline timers once the request has settled and the
+    // deadline no longer governs anything. unref alone only lets the Node.js
+    // process exit early — Deno's test sanitizer and browsers still see a
+    // pending timer for the full timeout window.
+    const clearDeadline = () => {
+      clearTotalTimer?.()
+      totalTimeout?.clear()
+    }
 
     if (headersMs === undefined && totalDeadline === undefined) {
-      return {response: await fetchFn(url, init), url, method, totalDeadline}
+      try {
+        return {response: await fetchFn(url, init), url, method, totalDeadline, clearDeadline}
+      } catch (reason) {
+        clearDeadline()
+        throw reason
+      }
     }
 
     // Deadlines competing with the fetch to settle the request promise.
@@ -144,13 +160,22 @@ export function createRequester(
     let fetching: Promise<FetchResponse> | undefined
     try {
       fetching = Promise.resolve(controller ? fetchFn(url, {...init, signal}) : fetchFn(url, init))
-      return {response: await Promise.race([fetching, ...deadlines]), url, method, totalDeadline}
+      return {
+        response: await Promise.race([fetching, ...deadlines]),
+        url,
+        method,
+        totalDeadline,
+        clearDeadline,
+      }
     } catch (reason) {
       // A deadline won the race (or the fetch itself failed): the fetch's
       // later settlement must not become an unhandled rejection. In
       // rejection-only mode the fetch was not aborted, so a late response
       // arrives with a dangling body — cancel it to release the connection.
       fetching?.then((response) => response.body?.cancel()).catch(() => {})
+      // The request has settled by rejection, so no deadline governs anything
+      // anymore — release the total-deadline timers.
+      clearDeadline()
       throw reason
     } finally {
       clearTimeout(timer)
@@ -163,11 +188,17 @@ export function createRequester(
    */
   async function getItBuffered(opts: RequestOptions): Promise<BufferedResponse> {
     const fetchFn: FetchFunction = opts.fetch ?? instanceFetch ?? globalThis.fetch
-    const {response, url, method, totalDeadline} = await performFetch(fetchFn, opts)
+    const {response, url, method, totalDeadline, clearDeadline} = await performFetch(fetchFn, opts)
     const httpErrors = opts.httpErrors ?? instanceHttpErrors ?? true
     // The rejection-only total deadline covers body download too, so keep
     // racing it while buffering (abort mode covers this via the init signal).
-    return raceDeadline(bufferAndCheck(response, httpErrors, url, method), totalDeadline)
+    // Once buffering settles the deadline is spent either way — release its
+    // timers.
+    try {
+      return await raceDeadline(bufferAndCheck(response, httpErrors, url, method), totalDeadline)
+    } finally {
+      clearDeadline()
+    }
   }
 
   // Compose wrapping middlewares around the core fetch
@@ -211,18 +242,30 @@ export function createRequester(
 
     async function getItStreamed(reqOpts: RequestOptions): Promise<BufferedResponse> {
       const fetchFn: FetchFunction = reqOpts.fetch ?? instanceFetch ?? globalThis.fetch
-      const {response, url, method, totalDeadline} = await performFetch(fetchFn, reqOpts)
+      const {response, url, method, totalDeadline, clearDeadline} = await performFetch(
+        fetchFn,
+        reqOpts,
+      )
       const httpErrors = reqOpts.httpErrors ?? instanceHttpErrors ?? true
 
       if (httpErrors && response.status >= 400) {
-        return raceDeadline(bufferAndCheck(response, httpErrors, url, method), totalDeadline)
+        try {
+          return await raceDeadline(
+            bufferAndCheck(response, httpErrors, url, method),
+            totalDeadline,
+          )
+        } finally {
+          clearDeadline()
+        }
       }
 
       // A rejection-only total deadline cannot govern the stream from here on
       // — a stream already handed to the caller cannot be retracted — so with
-      // `signal: false` it only covers up to response headers. The deadline
-      // promise is pre-armed with a catch handler, so its eventual rejection
-      // stays handled.
+      // `signal: false` it only covers up to response headers, and its timer
+      // can be released at hand-off. In abort mode (totalDeadline undefined)
+      // the deadline still governs the stream via the fetch-init signal, so
+      // its timer must stay armed.
+      if (totalDeadline !== undefined) clearDeadline()
       capturedResponse = response
       return createBufferedResponse(
         response.status,
@@ -363,16 +406,21 @@ function unrefTimer(timer: unknown): void {
  * Creates the rejection-only (`timeout: {signal: false}`) total deadline: a
  * promise that rejects with `reason` once `ms` elapses. Pre-armed with a
  * no-op catch handler so the rejection never becomes "unhandled" when the
- * guarded work settles first — like the abort-based total deadline, the timer
- * is unref'd rather than cleared, and firing after the race is won is
- * harmless.
+ * guarded work settles first. The timer is unref'd so it cannot hold the
+ * Node.js event loop open, and `clear` releases it entirely once the request
+ * settles.
  */
-function rejectAfterTimeout(ms: number, reason: unknown): Promise<never> {
+function rejectAfterTimeout(
+  ms: number,
+  reason: unknown,
+): {deadline: Promise<never>; clear: () => void} {
+  let timer: ReturnType<typeof setTimeout> | undefined
   const deadline = new Promise<never>((_, reject) => {
-    unrefTimer(setTimeout(() => reject(reason), ms))
+    timer = setTimeout(() => reject(reason), ms)
+    unrefTimer(timer)
   })
   deadline.catch(() => {})
-  return deadline
+  return {deadline, clear: () => clearTimeout(timer)}
 }
 
 /**
@@ -456,7 +504,7 @@ function buildFetchArgs(
   opts: RequestOptions,
   totalMs: number | undefined,
   instanceCredentials: 'include' | 'omit' | 'same-origin' | undefined,
-): {url: string; init: FetchInit} {
+): {url: string; init: FetchInit; clearTotalTimer: (() => void) | undefined} {
   let url = opts.url
 
   // Query string — merge query params into URL
@@ -509,21 +557,22 @@ function buildFetchArgs(
 
   // Signal — build the final abort signal (totalMs already resolved by resolveTimeout)
   let signal: AbortSignal | undefined = opts.signal
+  let clearTotalTimer: (() => void) | undefined
   if (totalMs !== undefined) {
     // Own the deadline timer instead of using AbortSignal.timeout(): WebKit
     // can garbage-collect an otherwise-unreferenced timeout signal behind
     // AbortSignal.any(), silently disarming the deadline. The timer callback
     // closure keeps this controller (and thus the abort chain) alive.
     const totalController = new AbortController()
-    unrefTimer(
-      setTimeout(
-        () =>
-          totalController.abort(
-            new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
-          ),
-        totalMs,
-      ),
+    const timer = setTimeout(
+      () =>
+        totalController.abort(
+          new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
+        ),
+      totalMs,
     )
+    unrefTimer(timer)
+    clearTotalTimer = () => clearTimeout(timer)
     signal = signal ? AbortSignal.any([signal, totalController.signal]) : totalController.signal
   }
   if (signal) init.signal = signal
@@ -533,7 +582,7 @@ function buildFetchArgs(
 
   if (opts.redirect) init.redirect = opts.redirect
 
-  return {url, init}
+  return {url, init, clearTotalTimer}
 }
 
 /**

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,5 +1,5 @@
 import {createRequester, type FetchInit, TimeoutError} from 'get-it'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {resolveTimeout} from '../src/createRequester'
 
 describe('TimeoutError', () => {
@@ -119,6 +119,28 @@ describe('resolveTimeout', () => {
 })
 
 const baseUrl = 'http://localhost:9980/req-test'
+
+/**
+ * Spies on the global timer functions so tests can assert that every timer
+ * created during a request is cleared once the request settles. `restore()`
+ * clears any leftover timers so a leak cannot outlive the test.
+ */
+function trackTimers() {
+  const setSpy = vi.spyOn(globalThis, 'setTimeout')
+  const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+  const created = () => setSpy.mock.results.map((result) => result.value)
+  const cleared = () => clearSpy.mock.calls.map(([timer]) => timer)
+  return {
+    created,
+    uncleared: () => created().filter((timer) => !cleared().includes(timer)),
+    restore: () => {
+      const leftovers = created().filter((timer) => !cleared().includes(timer))
+      setSpy.mockRestore()
+      clearSpy.mockRestore()
+      for (const timer of leftovers) clearTimeout(timer)
+    },
+  }
+}
 
 describe('structured timeout behavior', () => {
   // happy-dom's fetch does not properly support AbortController on network requests
@@ -315,6 +337,112 @@ describe('structured timeout behavior', () => {
     // promise nothing subscribes to (vitest fails the test on unhandled
     // rejections).
     await new Promise((resolve) => setTimeout(resolve, 400))
+  })
+
+  it('clears the total-deadline timer once the body is buffered (abort mode)', async () => {
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000},
+      fetch: () => Promise.resolve(new Response('ok')),
+    })
+    const timers = trackTimers()
+    try {
+      const res = await request('/plain-text')
+      expect(res.text()).toBe('ok')
+      expect(timers.created()).not.toHaveLength(0)
+      expect(timers.uncleared()).toHaveLength(0)
+    } finally {
+      timers.restore()
+    }
+  })
+
+  it('clears the total-deadline timer once the body is buffered (rejection-only mode)', async () => {
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000, signal: false},
+      fetch: () => Promise.resolve(new Response('ok')),
+    })
+    const timers = trackTimers()
+    try {
+      const res = await request('/plain-text')
+      expect(res.text()).toBe('ok')
+      expect(timers.created()).not.toHaveLength(0)
+      expect(timers.uncleared()).toHaveLength(0)
+    } finally {
+      timers.restore()
+    }
+  })
+
+  it('clears the total-deadline timer when the fetch rejects (abort mode)', async () => {
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000},
+      fetch: () => Promise.reject(new Error('boom')),
+    })
+    const timers = trackTimers()
+    try {
+      await expect(request('/plain-text')).rejects.toThrow('boom')
+      expect(timers.created()).not.toHaveLength(0)
+      expect(timers.uncleared()).toHaveLength(0)
+    } finally {
+      timers.restore()
+    }
+  })
+
+  it('clears the total-deadline timer when the fetch rejects (rejection-only mode)', async () => {
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000, headers: 15_000, signal: false},
+      fetch: () => Promise.reject(new Error('boom')),
+    })
+    const timers = trackTimers()
+    try {
+      await expect(request('/plain-text')).rejects.toThrow('boom')
+      expect(timers.created()).not.toHaveLength(0)
+      expect(timers.uncleared()).toHaveLength(0)
+    } finally {
+      timers.restore()
+    }
+  })
+
+  it('clears the rejection-only total-deadline timer once a stream is handed over', async () => {
+    // With `signal: false` the total deadline only covers up to response
+    // headers in stream mode, so its timer serves no purpose once the stream
+    // is handed to the caller.
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000, signal: false},
+      fetch: () => Promise.resolve(new Response('streamed')),
+    })
+    const timers = trackTimers()
+    try {
+      const res = await request({url: '/plain-text', as: 'stream'})
+      expect(res.status).toBe(200)
+      expect(timers.created()).not.toHaveLength(0)
+      expect(timers.uncleared()).toHaveLength(0)
+      await res.body.cancel()
+    } finally {
+      timers.restore()
+    }
+  })
+
+  it('keeps the abort-mode total-deadline timer armed while a stream is unconsumed', async () => {
+    // In abort mode the total deadline governs the body stream too, so the
+    // timer must stay armed after the stream is handed to the caller.
+    const request = createRequester({
+      base: baseUrl,
+      timeout: {total: 30_000},
+      fetch: () => Promise.resolve(new Response('streamed')),
+    })
+    const timers = trackTimers()
+    try {
+      const res = await request({url: '/plain-text', as: 'stream'})
+      expect(res.status).toBe(200)
+      expect(timers.uncleared()).toHaveLength(1)
+      await res.body.cancel()
+    } finally {
+      timers.restore()
+    }
   })
 
   it('{headers, total: false} lets a slow stream complete', async () => {


### PR DESCRIPTION
## Problem

The total-deadline timers were only `unref`'d, never `clearTimeout`-ed:

- the abort-mode timer created in `buildFetchArgs`
- the rejection-only (`timeout: {signal: false}`) timer created in `rejectAfterTimeout`

`unref` only lets the Node.js process exit early. Deno's test sanitizer and browsers still see a pending timer for the full timeout window (120s by default), which fails Deno tests with leak errors and leaves stray timers in browser environments.

## Fix

Timers are now cleared once the request settles. Clearing happens after body buffering, not at headers, since the total deadline governs the download too:

- `buildFetchArgs` returns a `clearTotalTimer` function for the abort-mode timer
- `rejectAfterTimeout` returns `{deadline, clear}` instead of a bare promise
- `performFetch` composes both into a `clearDeadline` it returns to callers, and calls it itself on every rejection path (headers timeout, fetch failure, sync throw)
- `getItBuffered` clears in a `finally` once buffering settles
- Stream mode: the error path (status >= 400, which buffers) clears after buffering; the success path clears only the rejection-only timer at hand-off. In abort mode the timer stays armed for handed-over streams, where it still governs the body via the fetch-init signal.

## Tests

Added a `trackTimers` helper that spies on global `setTimeout`/`clearTimeout` and asserts no timer created during a request survives it:

- buffered success and fetch rejection, in both abort and rejection-only modes
- rejection-only stream hand-off
- a regression guard asserting the abort-mode timer stays armed while a stream is unconsumed

Five of the six failed before the fix (exactly one leaked timer each); all pass after, across the default, happy-dom, and vercel-edge configs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core timeout/race logic across buffered and stream paths; behavior is nuanced (when to clear vs keep armed) but is covered by new timer-leak tests.
> 
> **Overview**
> **Total-deadline timers are now `clearTimeout`'d when they no longer matter**, instead of relying only on `unref`. That fixes stray timers in Deno test sanitizers and browsers after fast requests (previously the default ~120s timer could linger until it fired).
> 
> `buildFetchArgs` exposes **`clearTotalTimer`** for abort-mode total timeouts; **`rejectAfterTimeout`** returns **`{deadline, clear}`** for rejection-only (`signal: false`) races. **`performFetch`** composes these into **`clearDeadline`**, invokes it on fetch failures and races lost to deadlines, and passes it to buffered/stream paths.
> 
> **Buffered responses** clear after body buffering finishes (in a `finally`). **Stream mode** clears the rejection-only timer at successful hand-off (headers-only coverage); **abort-mode** keeps one timer armed while the caller still holds an unconsumed stream so the fetch signal can still enforce the total deadline on the body.
> 
> Tests add a **`trackTimers`** helper and cases for success, rejection, buffered vs stream, and abort vs rejection-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d06248d7c5a6e3b273d7498cbab34bee6417ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->