### PR TITLE
fix: don't duplicate first byte of compressed response streams

### DIFF
--- a/.changeset/stream-probe-duplicates-first-byte.md
+++ b/.changeset/stream-probe-duplicates-first-byte.md
@@ -1,0 +1,5 @@
+---
+'get-it': patch
+---
+
+fix: don't duplicate the first byte of compressed response streams

--- a/src/request/node-request.ts
+++ b/src/request/node-request.ts
@@ -251,9 +251,9 @@ export const httpRequester: HttpRequest = (context, cb) => {
       //
       // When the response was piped through a transform (decompress-response
       // or onHeaders middleware), neither check above works. We instead wait
-      // for 'readable' on resStream and peek one byte: null means the stream
-      // ended empty, so we resume; non-null means real data, so we unshift it
-      // back for the caller to consume.
+      // for 'readable' on resStream and inspect its buffer without consuming
+      // it: 'readable' fires at EOF too, so an empty buffer at that point means
+      // the stream ended without data and needs draining.
       process.nextTick(() => {
         if (resStream.readableFlowing) {
           return
@@ -273,14 +273,11 @@ export const httpRequester: HttpRequest = (context, cb) => {
         // original IncomingMessage. Peek via 'readable' instead.
         if (response.complete && response.readableFlowing) {
           resStream.once('readable', () => {
-            if (resStream.readableFlowing) {
-              return
-            }
-            const chunk = resStream.read(1)
-            if (chunk === null) {
+            // Must not read() here: read() emits 'data' to any consumer that
+            // has already attached, and unshift()-ing the chunk back makes it
+            // arrive a second time, corrupting the payload.
+            if (resStream.readableLength === 0) {
               resStream.resume()
-            } else {
-              resStream.unshift(chunk)
             }
           })
         }

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1,4 +1,5 @@
 import {environment, getIt} from 'get-it'
+import {promise} from 'get-it/middleware'
 import {getUri} from 'get-uri'
 import {Readable} from 'stream'
 import {describe, expect, it} from 'vitest'
@@ -102,6 +103,26 @@ describe.runIf(environment === 'node')('streams', {timeout: 15000}, () => {
       })
       req.error.subscribe(reject)
     }))
+
+  it('should not alter compressed response streams consumed on a later tick', async () => {
+    const expected = JSON.stringify(['harder', 'better', 'faster', 'stronger'])
+    const request = getIt([baseUrl, debugRequest, promise()])
+
+    // Callers that await the response promise, then open a destination before
+    // piping, attach their consumer after the drain guard has run. That must
+    // leave the payload byte-identical.
+    for (let i = 0; i < 10; i++) {
+      const res: any = await request({url: '/gzip', stream: true})
+      await new Promise((resolve) => setImmediate(resolve))
+
+      const body = await new Promise<Buffer>((resolve, reject) =>
+        concat(res.body, (err: any, data: Buffer) => (err ? reject(err) : resolve(data))),
+      )
+
+      expect(body.toString('utf8')).to.eq(expected)
+      expect(body.length).to.eq(Buffer.byteLength(expected))
+    }
+  })
 
   it('should drain empty compressed response streams', async () =>
     new Promise((resolve, reject) => {


### PR DESCRIPTION
### Description

The empty-body drain guard for piped responses peeked at the stream with `read(1)` and put the chunk back with `unshift()`. Both steps are observable: `read()` emits 'data' to any consumer that has already attached, and the `unshift()ed` chunk is then delivered a second time. Callers piping a compressed response to disk get a payload one byte too long, with byte 0 duplicated (`<<svg` for an SVG).

Registering the 'readable' listener is itself what exposes this — it takes the stream out of flowing mode, so the `readableFlowing` guard inside the handler never short-circuits for an already-attached consumer.

Affects 8.7.1 through 8.8.1.

### What to review

The fix. Detect emptiness without consuming instead: 'readable' also fires at EOF, so an empty buffer at that point means the body was empty and the stream needs draining. Everything the guard was added for still holds — empty, 204, HEAD and empty-gzip responses all still drain without the caller reading them.

Related test-only PR in `export`: https://github.com/sanity-io/export/pull/56 (fails when 8.8.1 used).

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Node streaming drain logic on compressed/piped responses; behavior change is targeted but affects all `stream: true` gzip paths.
> 
> **Overview**
> Fixes a regression in the **streaming response empty-body drain guard** for piped bodies (e.g. gzip via `decompress-response`). The guard no longer peeks with `read(1)` and `unshift()`; it waits for `readable` and treats **`readableLength === 0` at EOF** as empty, then calls `resume()` only in that case.
> 
> That removes **duplicate first-byte / inflated payload length** when consumers attach after the guard runs (e.g. await + `setImmediate` before piping), while keeping drain behavior for empty, 204, HEAD, and empty-gzip streams.
> 
> Adds a **regression test** (10 iterations with `promise()` middleware) asserting gzip stream bodies stay byte-identical when consumed on a later tick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263f347e4c3d0453e598806752e85aa414294207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->