### PR TITLE
fix: don't leave streams piped by onHeaders middleware permanently paused

### DIFF
--- a/.changeset/drain-guard-leaves-piped-streams-paused.md
+++ b/.changeset/drain-guard-leaves-piped-streams-paused.md
@@ -1,0 +1,5 @@
+---
+'get-it': patch
+---
+
+fix: don't leave streams piped by `onHeaders` middleware permanently paused

--- a/src/request/node-request.ts
+++ b/src/request/node-request.ts
@@ -23,6 +23,18 @@ import {NodeRequestError} from './node-request-error'
 const isStream = (stream: any): stream is Stream =>
   stream !== null && typeof stream === 'object' && typeof stream.pipe === 'function'
 
+/**
+ * Whether a stream has a writable side, and will therefore emit 'finish' once
+ * everything piped into it has been written and flushed. `resStream` is only
+ * writable when decompress-response or an `onHeaders` middleware piped the
+ * response through a transform; otherwise it is the raw IncomingMessage.
+ */
+const hasWritableSide = (stream: unknown): boolean =>
+  typeof stream === 'object' &&
+  stream !== null &&
+  'write' in stream &&
+  typeof stream.write === 'function'
+
 /** @public */
 export const adapter: RequestAdapter = 'node'
 
@@ -250,10 +262,18 @@ export const httpRequester: HttpRequest = (context, cb) => {
       // readableLength to 0 even for non-empty bodies.
       //
       // When the response was piped through a transform (decompress-response
-      // or onHeaders middleware), neither check above works. We instead wait
-      // for 'readable' on resStream and inspect its buffer without consuming
-      // it: 'readable' fires at EOF too, so an empty buffer at that point means
-      // the stream ended without data and needs draining.
+      // or onHeaders middleware), neither check above works. We then wait for
+      // the transform's writable side to finish, which means every byte it will
+      // ever produce has been pushed, and read `readableLength` to see whether
+      // that was nothing at all.
+      //
+      // Whatever we do here must not observe resStream through a listener that
+      // changes its mode. Attaching 'readable' sets `flowing = false`, and for
+      // userland streams (through2/readable-stream@3, as used by the progress
+      // middleware) that is never reset, so a consumer attaching later is
+      // deadlocked: `.on('data')` skips its implicit resume() when flowing is
+      // already false. Reading properties is safe; listening for 'finish' on
+      // the writable side is safe. Listening for 'readable' is not.
       process.nextTick(() => {
         if (resStream.readableFlowing) {
           return
@@ -270,12 +290,13 @@ export const httpRequester: HttpRequest = (context, cb) => {
 
         // Piped case: response was consumed by decompress-response or
         // onHeaders middleware, so we cannot inspect readableLength on the
-        // original IncomingMessage. Peek via 'readable' instead.
-        if (response.complete && response.readableFlowing) {
-          resStream.once('readable', () => {
-            // Must not read() here: read() emits 'data' to any consumer that
-            // has already attached, and unshift()-ing the chunk back makes it
-            // arrive a second time, corrupting the payload.
+        // original IncomingMessage. Wait for the transform to finish writing
+        // instead, then inspect the buffer it produced.
+        if (response.complete && response.readableFlowing && hasWritableSide(resStream)) {
+          resStream.once('finish', () => {
+            // 'finish' fires after the writable side has ended and _flush has
+            // run, so nothing more will be pushed. An empty buffer here means
+            // the transform produced no output at all.
             if (resStream.readableLength === 0) {
               resStream.resume()
             }

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1,5 +1,5 @@
 import {environment, getIt} from 'get-it'
-import {promise} from 'get-it/middleware'
+import {progress, promise} from 'get-it/middleware'
 import {getUri} from 'get-uri'
 import {Readable} from 'stream'
 import {describe, expect, it} from 'vitest'
@@ -123,6 +123,65 @@ describe.runIf(environment === 'node')('streams', {timeout: 15000}, () => {
       expect(body.length).to.eq(Buffer.byteLength(expected))
     }
   })
+
+  it('should deliver plain response streams piped by onHeaders middleware on a later tick', async () => {
+    const expected = 'Just some plain text for you to consume'
+    const request = getIt([baseUrl, debugRequest, promise(), progress()])
+
+    // The progress middleware pipes the response through a through2 transform.
+    // The drain guard must not leave that transform paused, or a consumer
+    // attaching on a later tick never receives anything.
+    for (let i = 0; i < 5; i++) {
+      const res: any = await request({url: '/plain-text', stream: true})
+      await new Promise((resolve) => setImmediate(resolve))
+
+      const body = await new Promise<Buffer>((resolve, reject) =>
+        concat(res.body, (err: any, data: Buffer) => (err ? reject(err) : resolve(data))),
+      )
+
+      expect(body.toString('utf8')).to.eq(expected)
+    }
+  })
+
+  it('should deliver compressed response streams piped by onHeaders middleware on a later tick', async () => {
+    const expected = JSON.stringify(['harder', 'better', 'faster', 'stronger'])
+    const request = getIt([baseUrl, debugRequest, promise(), progress()])
+
+    for (let i = 0; i < 5; i++) {
+      const res: any = await request({url: '/gzip', stream: true})
+      // A macrotask boundary: later than setImmediate, so the guard has always
+      // finished before the consumer attaches.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      const body = await new Promise<Buffer>((resolve, reject) =>
+        concat(res.body, (err: any, data: Buffer) => (err ? reject(err) : resolve(data))),
+      )
+
+      expect(body.toString('utf8')).to.eq(expected)
+    }
+  })
+
+  const emptyBodyCases = [
+    ['empty', {url: '/empty'}],
+    ['204 No Content', {url: '/no-content'}],
+    ['HEAD', {url: '/plain-text', method: 'HEAD'}],
+    ['empty compressed', {url: '/gzip-empty'}],
+  ] as const
+
+  for (const [name, requestOptions] of emptyBodyCases) {
+    it(`should drain ${name} response streams piped by onHeaders middleware`, async () =>
+      new Promise((resolve, reject) => {
+        const request = getIt([baseUrl, debugRequest, progress()])
+        const req = request({...requestOptions, stream: true})
+        req.response.subscribe((res: any) => {
+          // Do NOT consume the stream. The progress middleware pipes the
+          // response through a transform, and that transform must still be
+          // drained so 'end' fires and the socket is released.
+          res.body.once('end', () => resolve(undefined))
+        })
+        req.error.subscribe(reject)
+      }))
+  }
 
   it('should drain empty compressed response streams', async () =>
     new Promise((resolve, reject) => {


### PR DESCRIPTION
### Description

Follow-up to #642. That PR fixed the `read()`/`unshift()` symptom of the empty-body drain guard. This fixes the other half: the guard detects emptiness by attaching a `'readable'` listener to `resStream`, which is the stream we just handed to the caller.

Attaching `'readable'` is not a passive observation. It sets `flowing = false` on the stream.

Node core papers over this: when the listener detaches, `updateReadableListening()` resets `flowing = null` if nothing is listening, so zlib transforms mostly got away with it. Userland streams do not get that reset. The `progress()` middleware pipes through `through2`, which depends on `readable-stream@3`, and that version's `updateReadableListening()` has no such branch:

```js
function updateReadableListening(self) {
  var state = self._readableState;
  state.readableListening = self.listenerCount('readable') > 0;
  if (state.resumeScheduled && !state.paused) {
    state.flowing = true;
  } else if (self.listenerCount('data') > 0) {
    self.resume();
  }
  // no `else if (!state.readableListening) state.flowing = null`
}
```

So once the guard's `once('readable')` fires and detaches, the stream is stuck at `flowing = false` permanently. A consumer attaching on a later tick is then deadlocked, because both `.on('data')` and `.pipe()` only call `resume()` `if (state.flowing !== false)`. The body sits fully buffered at EOF and never delivers a single byte.

Anyone using `progress()` with `stream: true` and consuming the body after an `await` hits this. It reproduces on every timing I tried (`await`-only, `nextTick`, `setImmediate`, `setTimeout(0)`), compressed and uncompressed. Affects 8.7.1 and later, including 8.8.2.

### What to review

The fix waits for `'finish'` on the transform's writable side instead. `'finish'` fires after the writable side has ended and `_flush` has run, so nothing more will ever be pushed, which makes an empty read buffer at that point a reliable "the transform produced no output" signal. It is also the property that matters here: reading `readableLength` is mode-neutral, and the only listener attached is on the writable side, which cannot affect how the caller reads.

The `hasWritableSide()` duck-type is import - `resStream` is only writable when something piped the response; otherwise it is the raw `IncomingMessage`, which never emits `'finish'`. Note that `through2` streams have no `writableFinished` getter, so checking for that property instead silently skips the branch and breaks draining for empty gzip.

Deliberately left alone: the `response.complete` condition on that branch. With `'finish'` semantics it is arguably unnecessary, since waiting is safe whether or not the message is complete, but no test requires removing it and this is a maintenance branch.

### Testing

Two tests that fail on `v8` today (both time out, since the stream never delivers) and pass with the fix:

- `should deliver plain response streams piped by onHeaders middleware on a later tick`
- `should deliver compressed response streams piped by onHeaders middleware on a later tick`

Plus four regression tests covering empty bodies (`empty`, `204`, `HEAD`, `gzip-empty`) piped through an `onHeaders` middleware. These pass before and after; they exist because the branch being changed is exactly the drain path, and there was no coverage of it with a piping middleware in place. They caught a real bug during development, when an earlier version of this fix used `'writableFinished' in resStream`.

Full suite green (24 files, 225 passed), typecheck clean, lint unchanged at 0 errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Node streaming drain logic for all piped responses; wrong empty detection could resume non-empty streams or fail to drain sockets, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a regression where the **empty-body drain guard** for `stream: true` responses left transforms from **`onHeaders` middleware** (e.g. `progress()`) stuck paused, so consumers attaching after `await` never received data.
> 
> The guard no longer uses **`once('readable')`** on `resStream`—that flips **`flowing = false`** on userland streams (`through2` / `readable-stream@3`) without resetting it. For piped transforms it now uses **`hasWritableSide()`** and waits for **`finish`** on the writable side, then **`resume()`** only if **`readableLength === 0`**.
> 
> Adds stream tests for plain and gzip bodies through **`progress()`** with delayed consumption, plus empty-body drain cases through piping middleware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a526c1004bbffc5791cf343acb4f1e20be00767a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->