### PR TITLE
fix(ci): keep v8 releases from latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
+      - name: Keep v8 release from becoming latest
+        if: steps.changesets.outputs.published == 'true'
+        run: gh release edit "v$(node -p "require('./package.json').version")" --latest=false
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Prevent v8 GitHub releases from replacing the v9 release from main as the repository's latest release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change gated on successful publish; no runtime or application code affected.
> 
> **Overview**
> Adds a post-publish step to the **v8** `release.yml` workflow so maintenance-line GitHub releases do not become the repo’s **Latest** release.
> 
> After Changesets successfully publishes (`steps.changesets.outputs.published == 'true'`), the workflow runs `gh release edit` on `v<package.json version>` with **`--latest=false`**, using the same app token as the rest of the job. This mirrors the existing npm strategy (`latest-v8` dist-tag) for GitHub’s release UI, leaving the v9 line from **main** as the visible latest release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8463946ed8fd6f0a6ee37d7d6e65374b39ee7e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->