### PR TITLE
docs: clean up readme, mock, migration and contribution guide

### DIFF
--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -29,8 +29,10 @@ if (
 }
 
 const PACKAGE_NAME = 'get-it'
-// Paths that affect the published package - changes elsewhere (CI, docs, tests) don't warrant a release
-const RELEVANT_PATHS = ['src/', 'package.json', 'package.config.ts']
+// Paths that affect the published package - changes elsewhere (CI, docs, tests) don't warrant a release.
+// The build config counts: tsdown.config.ts controls the entry points and the exports map, and
+// tsconfig.dist.json controls declaration emit, so either can change what consumers receive.
+const RELEVANT_PATHS = ['src/', 'package.json', 'tsdown.config.ts', 'tsconfig.dist.json']
 
 const CHANGESET_FILE = `.changeset/pr-${PR_NUMBER}.md`
 const AUTO_GENERATED_MARKER = '<!-- auto-generated -->'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,79 +1,10 @@
-## TypeScript: Type Safety is Non-Negotiable
+# AGENTS.md
 
-**NEVER use type assertions (`as`, `<Type>`, `as any`, `as unknown as X`).** There are zero acceptable uses in this codebase — not in production code, not in tests, not "just this once."
+The rules for this repository are in [CONTRIBUTING.md](CONTRIBUTING.md). Read that file before you write code.
 
-When a type doesn't match, it means one of these:
+Two rules matter most:
 
-1. The upstream type is wrong — fix it at the source.
-2. You need to narrow — use `typeof`, `instanceof`, `in`, discriminated unions, or a type guard.
-3. You need a user-defined type guard — write an `is` predicate function.
+- **Use no type assertions.** See [TypeScript: no type assertions](CONTRIBUTING.md#typescript-no-type-assertions).
+- **Mock no modules.** See [Testing: real code, not mocks](CONTRIBUTING.md#testing-real-code-not-mocks).
 
-```ts
-// WRONG — every single one of these
-const value = response as MyType
-const data = result as any
-const headers = obj as Record<string, string>
-const parsed = JSON.parse(raw) as Config
-
-// RIGHT — narrow instead
-function isMyType(value: unknown): value is MyType {
-  return typeof value === 'object' && value !== null && 'key' in value
-}
-
-if (isMyType(response)) {
-  // response is MyType here
-}
-```
-
-If `JSON.parse` returns `unknown` and you need a specific shape, write a type guard that validates the shape. If a library returns `any`, wrap it with a guard at the boundary. No shortcuts.
-
-## Testing: Real Code, Not Mocks
-
-**Prefer testing real implementations over mocking.** If you need to test internal behavior, export the function — don't mock it.
-
-### Module structure
-
-- `index.ts` exports the public API — what consumers import.
-- Internal helper functions that tests need to exercise directly CAN be exported from their own module files, but **MUST** be marked `@internal` in JSDoc.
-- Tests import internal functions directly and test them with real inputs/outputs.
-
-```ts
-// src/resolve.ts
-/**
- * Resolves a potentially relative URL against a base.
- * @internal
- */
-export function resolveUrl(base: string, url: string): string {
-  // ...
-}
-
-// src/index.ts — public API only
-export {createRequester} from './createRequester'
-export type {RequestOptions, BufferedResponse} from './types'
-// resolveUrl is NOT re-exported here
-```
-
-### What "no mocks" means in practice
-
-- **Don't mock modules** — no `vi.mock()`, no `jest.mock()`.
-- **Don't mock functions on objects** — no `vi.spyOn(obj, 'method').mockImplementation(...)`.
-- **Do use the injectable `fetch` option** — this is the designed-in seam. Providing a fake `fetch` to `createRequester({ fetch: fakeFetch })` is not mocking, it's using the API as intended.
-- **Do use the real test HTTP server** — it's there for a reason. Prefer real HTTP requests over intercepting fetch.
-- **Do test small units directly** — if a function is worth testing, it's worth exporting (with `@internal`).
-
-```ts
-// WRONG
-vi.mock('../src/resolve', () => ({
-  resolveUrl: vi.fn().mockReturnValue('http://example.com/foo'),
-}))
-
-// RIGHT — test the real function
-import {resolveUrl} from '../src/resolve'
-expect(resolveUrl('http://example.com', '/foo')).toBe('http://example.com/foo')
-```
-
-### When faking is acceptable
-
-- Providing a `fetch` function to `createRequester()` — that's dependency injection, not mocking.
-- Providing a `log` function to `debug()` middleware — same idea, it's a designed-in option.
-- Fake timers (`vi.useFakeTimers()`) for testing timeout/delay behavior — but prefer real short delays when practical.
+CONTRIBUTING.md also covers the development commands, the rules for dependencies and bundle size, and how pull requests and releases work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to get-it
+
+Thank you for your interest in get-it. We welcome bug reports, bug fixes, documentation, and new features.
+
+## Dependencies and bundle size
+
+get-it runs in browsers and in edge runtimes, so the size of the bundle is important. Two rules follow from this:
+
+- **Do not add a new dependency unless there is no other option.** get-it has one runtime dependency: `undici`, for proxy support in Node.js and Bun. In most cases, the code belongs in this repository and not in a new package.
+- **Keep the bundle small.** If a change adds bytes, give the number in the pull request.
+
+To measure the browser entry point, run `pnpm report-size`. It gives the raw size and the gzip size.
+
+If your change needs a new dependency, give the reason in the pull request. For a large change, open an issue first. We can then agree on the approach before you write the code.
+
+## Development
+
+You need Node.js 22.12 or later, and pnpm.
+
+```bash
+pnpm install
+pnpm test  # unit tests
+pnpm check # format, lint, knip, and typecheck
+```
+
+`pnpm test:all` runs the tests in every supported runtime: Node.js, Bun, Deno, workerd, Vercel Edge, React Server Components, and happy-dom. CI runs these tests on each pull request, so you do not have to run them all locally.
+
+Before you write code, read the two sections below. They hold the rules for TypeScript and for tests.
+
+## TypeScript: no type assertions
+
+**Never use a type assertion (`as`, `<Type>`, `as any`, `as unknown as X`).** There is no acceptable use in this repository, in production code or in tests.
+
+When a type does not match, one of these is true:
+
+1. The upstream type is wrong. Correct it at the source.
+2. You must narrow the type. Use `typeof`, `instanceof`, `in`, a discriminated union, or a type guard.
+3. You need a user-defined type guard. Write an `is` predicate function.
+
+```ts
+// WRONG: all of these
+const value = response as MyType
+const data = result as any
+const headers = obj as Record<string, string>
+const parsed = JSON.parse(raw) as Config
+
+// RIGHT: narrow instead
+function isMyType(value: unknown): value is MyType {
+  return typeof value === 'object' && value !== null && 'key' in value
+}
+
+if (isMyType(response)) {
+  // response is MyType here
+}
+```
+
+If `JSON.parse` returns `unknown` and you need a specific shape, write a type guard for that shape. If a library returns `any`, wrap it with a type guard at the boundary. Use no shortcuts.
+
+## Testing: real code, not mocks
+
+Exercise the real implementation. If you must reach internal behavior, export the function. Do not mock it.
+
+### Module structure
+
+- `index.ts` exports the public API. This is what consumers import.
+- You can export an internal helper function from its own module file, if a test needs it directly. You **must** mark that function `@internal` in the JSDoc.
+- A test imports the internal function directly and gives it real inputs.
+
+```ts
+// src/resolve.ts
+/**
+ * Resolves a potentially relative URL against a base.
+ * @internal
+ */
+export function resolveUrl(base: string, url: string): string {
+  // ...
+}
+
+// src/index.ts: public API only
+export {createRequester} from './createRequester'
+export type {RequestOptions, BufferedResponse} from './types'
+// resolveUrl is NOT re-exported here
+```
+
+### What "no mocks" means
+
+- **Do not mock a module.** Do not use `vi.mock()` or `jest.mock()`.
+- **Do not mock a function on an object.** Do not use `vi.spyOn(obj, 'method').mockImplementation(...)`.
+- **Use the injectable `fetch` option.** This option is the designed-in seam. A fake `fetch` in `createRequester({fetch: fakeFetch})` is not a mock. It is the intended use of the API.
+- **Use the real HTTP server in the test suite.** Prefer a real HTTP request to an interception of fetch.
+- **Exercise small units directly.** If a function needs a test, export it and mark it `@internal`.
+
+```ts
+// WRONG
+vi.mock('../src/resolve', () => ({
+  resolveUrl: vi.fn().mockReturnValue('http://example.com/foo'),
+}))
+
+// RIGHT: exercise the real function
+import {resolveUrl} from '../src/resolve'
+expect(resolveUrl('http://example.com', '/foo')).toBe('http://example.com/foo')
+```
+
+### When a fake is acceptable
+
+- A `fetch` function that you give to `createRequester()`. This is dependency injection, not a mock.
+- A `log` function that you give to the `debug()` middleware. This is also a designed-in option.
+- Fake timers (`vi.useFakeTimers()`) for timeout and delay behavior. Prefer a real short delay when that is practical.
+
+## Pull requests and changesets
+
+get-it uses [changesets](https://github.com/changesets/changesets) for the version numbers and the changelog. In most cases you do not write a changeset. A bot writes one from the title of your pull request.
+
+Give the pull request a conventional-commit title. A CI check enforces this format. The title sets the version bump:
+
+- `feat:` gives a minor release
+- `fix:`, `perf:`, or `revert:` gives a patch release
+- `feat!:`, or a `BREAKING CHANGE:` line in the body, gives a major release
+- All other types (`docs:`, `chore:`, `test:`, `build:`, `ci:`, `refactor:`, `style:`) give no release
+
+The bot writes a changeset only when the pull request changes a file that affects the published package: `src/`, `package.json`, `tsdown.config.ts`, or `tsconfig.dist.json`. A change to the tests or to the documentation does not start a release.
+
+To write your own release note, run `pnpm changeset` and commit the file. The bot then makes no changes to your pull request. You can also edit the changeset that the bot wrote. If you do this, delete the `<!-- auto-generated -->` line at the top of the file. The bot then keeps your text.
+
+## Release
+
+This section is for maintainers.
+
+A merge to `main` starts the Release workflow. The workflow collects the changesets and opens a pull request with the title "chore: version packages". This pull request holds the new version number and the new changelog entries.
+
+To publish, merge that pull request. The workflow then publishes the package to npm.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![gzip size][gzip-badge]][bundlephobia]
 [![size][size-badge]][bundlephobia]
 
-Generic HTTP request library for node.js (>= 22.12), browsers, and edge runtimes. Built on `fetch()`.
+Generic HTTP request library for Node.js (>= 22.12), browsers, Deno, Bun, and edge runtimes. Built on `fetch()`.
 
 ## Features
 
-- Promise-based API with full TypeScript support
+- Promise-based API with TypeScript types
 - Automatic JSON serialization/deserialization
 - Base URL and default headers
 - HTTP error throwing (on by default)
@@ -19,7 +19,6 @@ Generic HTTP request library for node.js (>= 22.12), browsers, and edge runtimes
 - Middleware system for retry, debug logging, and custom logic
 - Injectable `fetch` for testing and custom transports
 - Built-in mock fetch with request matching, recording, and vitest matchers
-- Works in Node.js, browsers, Deno, Bun, and edge runtimes
 
 ## Installation
 
@@ -38,17 +37,17 @@ const request = createRequester({
 })
 
 // Simple GET
-const res = await request('/users')
-console.log(res.json())
+const users = await request('/users')
+console.log(users.json())
 
 // POST with JSON body (auto-serialized)
-const res = await request({
+const created = await request({
   url: '/users',
   method: 'POST',
   body: {name: 'Espen'},
   as: 'json',
 })
-console.log(res.body) // parsed JSON
+console.log(created.body) // parsed JSON
 ```
 
 ## Response
@@ -63,7 +62,7 @@ The response object depends on the `as` option:
 | `'stream'`  | `ReadableStream<Uint8Array>`                    | no        |
 
 ```ts
-// Default — buffered with convenience methods
+// Default: buffered, with convenience methods
 const res = await request('/data')
 res.status // number
 res.statusText // string
@@ -73,45 +72,45 @@ res.json() // parse as JSON (synchronous)
 res.text() // decode as string (synchronous)
 
 // Typed JSON
-const res = await request<User[]>({url: '/users', as: 'json'})
-res.body // User[]
+const users = await request<User[]>({url: '/users', as: 'json'})
+users.body // User[]
 
 // Streaming
-const res = await request({url: '/large-file', as: 'stream'})
-res.body // ReadableStream<Uint8Array>
+const file = await request({url: '/large-file', as: 'stream'})
+file.body // ReadableStream<Uint8Array>
 ```
 
 ## Options
 
 ### Instance options (`createRequester`)
 
-| Option       | Type                                | Default            | Description                                                      |
-| ------------ | ----------------------------------- | ------------------ | ---------------------------------------------------------------- |
-| `base`       | `string`                            | —                  | Base URL prepended to relative paths                             |
-| `headers`    | `FetchHeaders`                      | —                  | Default headers for all requests                                 |
-| `httpErrors` | `boolean`                           | `true`             | Throw `HttpError` on status >= 400                               |
-| `timeout`    | `number \| false \| TimeoutOptions` | —                  | Timeout in ms, or `{total, headers}` — see [Timeouts](#timeouts) |
-| `fetch`      | `FetchFunction`                     | `globalThis.fetch` | Custom fetch implementation                                      |
-| `middleware` | `Array`                             | `[]`               | Transform and wrapping middleware                                |
+| Option       | Type                                | Default            | Description                                                     |
+| ------------ | ----------------------------------- | ------------------ | --------------------------------------------------------------- |
+| `base`       | `string`                            | none               | Base URL prepended to relative paths                            |
+| `headers`    | `FetchHeaders`                      | none               | Default headers for all requests                                |
+| `httpErrors` | `boolean`                           | `true`             | Throw `HttpError` on status >= 400                              |
+| `timeout`    | `number \| false \| TimeoutOptions` | `120_000` total    | Timeout in ms, or `{total, headers}`. See [Timeouts](#timeouts) |
+| `fetch`      | `FetchFunction`                     | `globalThis.fetch` | Custom fetch implementation                                     |
+| `middleware` | `Array`                             | `[]`               | Transform and wrapping middleware                               |
 
 ### Per-request options
 
-| Option        | Type                                                       | Description                                                     |
-| ------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
-| `url`         | `string`                                                   | Request URL (required)                                          |
-| `method`      | `string`                                                   | HTTP method                                                     |
-| `body`        | `unknown`                                                  | Request body (objects auto-serialized as JSON)                  |
-| `headers`     | `FetchHeaders`                                             | Merged with instance headers                                    |
-| `query`       | `Record<string, string \| number \| boolean \| undefined>` | URL query parameters                                            |
-| `as`          | `'json' \| 'text' \| 'stream'`                             | Response body type                                              |
-| `signal`      | `AbortSignal`                                              | Cancellation signal                                             |
-| `httpErrors`  | `boolean`                                                  | Override instance setting                                       |
-| `timeout`     | `number \| false \| TimeoutOptions`                        | Override instance timeout (replaces it wholesale)               |
-| `fetch`       | `FetchFunction`                                            | Override instance fetch                                         |
-| `redirect`    | `'error' \| 'follow' \| 'manual'`                          | Redirect strategy (`'manual'` is opaque in browsers - see note) |
-| `credentials` | `'include' \| 'omit' \| 'same-origin'`                     | Credentials mode (browser-only)                                 |
+| Option        | Type                                                       | Description                                                    |
+| ------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| `url`         | `string`                                                   | Request URL (required)                                         |
+| `method`      | `string`                                                   | HTTP method                                                    |
+| `body`        | `unknown`                                                  | Request body (objects auto-serialized as JSON)                 |
+| `headers`     | `FetchHeaders`                                             | Merged with instance headers                                   |
+| `query`       | `Record<string, string \| number \| boolean \| undefined>` | URL query parameters                                           |
+| `as`          | `'json' \| 'text' \| 'stream'`                             | Response body type                                             |
+| `signal`      | `AbortSignal`                                              | Cancellation signal                                            |
+| `httpErrors`  | `boolean`                                                  | Override instance setting                                      |
+| `timeout`     | `number \| false \| TimeoutOptions`                        | Override instance timeout (replaces it wholesale)              |
+| `fetch`       | `FetchFunction`                                            | Override instance fetch                                        |
+| `redirect`    | `'error' \| 'follow' \| 'manual'`                          | Redirect strategy (`'manual'` is opaque in browsers, see note) |
+| `credentials` | `'include' \| 'omit' \| 'same-origin'`                     | Credentials mode (browser-only)                                |
 
-> **Note on `redirect: 'manual'`:** In browsers this yields an opaque-redirect response (status `0`, empty headers) per the Fetch spec, so the 3xx status and headers (e.g. `location`) are unreadable. Reading them neither throws nor warns - `headers.get()` returns `null` and iteration is empty - so detect the case via `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes, workers) return the real 3xx response, so its status and headers are readable.
+> **Note on `redirect: 'manual'`:** In browsers this yields an opaque-redirect response (status `0`, empty headers) per the Fetch spec, so the 3xx status and headers (such as `location`) are unreadable. Reading them neither throws nor warns: `headers.get()` returns `null` and iteration is empty. Detect the case via `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes, workers) return the real 3xx response, so its status and headers are readable.
 
 ## Timeouts
 
@@ -120,20 +119,20 @@ res.body // ReadableStream<Uint8Array>
 ```ts
 const request = createRequester({
   timeout: {
-    total: 120_000, // total deadline, request start through body (default 120 000)
+    total: 120_000, // total deadline, request start through body (default 120_000)
     headers: 15_000, // max time to receive response headers, per attempt (disabled by default)
   },
 })
 ```
 
-- `total` — the existing deadline. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with a `TimeoutError` DOMException, which the `retry()` middleware never retries. When combined with the retry() middleware, the deadline applies per attempt - each retry gets a fresh total timer.
-- `headers` — time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. Because the timer lives inside the middleware chain, each retry attempt gets a fresh timer — no middleware ordering requirements.
+- `total`: the deadline you get when passing a plain number. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with a `TimeoutError` DOMException, which the `retry()` middleware never retries. Combined with the retry() middleware, the deadline applies per attempt, so each retry gets a fresh total timer.
+- `headers`: time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. The timer lives inside the middleware chain, so each retry attempt gets a fresh timer and there are no middleware ordering requirements.
 
 ### Escape hatch: rejection-only timeouts (`signal: false`)
 
-By default, timeouts attach an abort signal to the fetch init - keep it that way unless an environment forces your hand. The known case: Next.js' patched fetch treats any signal-carrying request as opted out of React Request Memoization, so RSC consumers would otherwise have to choose between timeouts and memoization. For that situation, `timeout: {total: 30_000, signal: false}` keeps the timeouts (both `total` and `headers`) as pure rejections: the request promise still rejects with the same errors at the deadline, but nothing is attached to the fetch init.
+By default, timeouts attach an abort signal to the fetch init. Keep it that way unless an environment forces your hand. Next.js is the one known case: its patched fetch treats any signal-carrying request as opted out of React Request Memoization, so RSC consumers would otherwise have to choose between timeouts and memoization. For that situation, `timeout: {total: 30_000, signal: false}` keeps both `total` and `headers` as pure rejections. The request promise still rejects with the same errors at the deadline, but nothing is attached to the fetch init.
 
-Understand what you are giving up: when a timeout wins, the underlying request is not torn down - it keeps running to completion in the background, holding its connection until the server finishes on its own. A caller-provided `signal` is passed through untouched and still aborts. In `as: 'stream'` mode, `total` only covers up to response headers (a stream already handed to you cannot be retracted).
+When a timeout wins, the underlying request is not torn down: it keeps running to completion in the background, holding its connection until the server finishes on its own. A caller-provided `signal` is passed through untouched and still aborts. In `as: 'stream'` mode, `total` only covers up to response headers, since a stream already handed to you cannot be retracted.
 
 For long-running streaming downloads, disable the total deadline and keep a headers timeout:
 
@@ -174,13 +173,13 @@ const promise = request({url: '/slow', signal: controller.signal})
 controller.abort()
 ```
 
-Timeout and user-provided signals are combined automatically with `AbortSignal.any()` - unless the timeout is rejection-only (`timeout: {signal: false}`), in which case the user-provided signal is passed through as-is.
+Timeout and user-provided signals are combined automatically with `AbortSignal.any()`. The exception is rejection-only timeouts (`timeout: {signal: false}`), where the user-provided signal is passed through as-is.
 
 ## Middleware
 
 Two types of middleware, passed in the `middleware` array:
 
-**Transform middleware** (object) — flat pipeline, invisible in stack traces:
+**Transform middleware** (object). Flat pipeline, invisible in stack traces:
 
 ```ts
 const addHeader: TransformMiddleware = {
@@ -193,7 +192,7 @@ const addHeader: TransformMiddleware = {
 }
 ```
 
-**Wrapping middleware** (function) — wraps the fetch call, appears in stack traces:
+**Wrapping middleware** (function). Wraps the fetch call, appears in stack traces:
 
 ```ts
 const logger: WrappingMiddleware = async (options, next) => {
@@ -214,7 +213,7 @@ const request = createRequester({
 })
 ```
 
-A per-request `maxRetries` option overrides the retry middleware's configured value for that request (`0` disables retries, higher values allow more attempts).
+A per-request `maxRetries` option overrides the retry middleware's configured value for that request. Set it to `0` to disable retries.
 
 ## Runtime proxy support
 
@@ -252,7 +251,7 @@ const request = createRequester({
 
 ## Testing
 
-`get-it/mock` provides a mock fetch for testing code that uses get-it. No network, no global patching — just inject `mock.fetch` where you'd normally pass `fetch`.
+`get-it/mock` provides a mock fetch for testing code that uses get-it. No network, no global patching: inject `mock.fetch` where you'd normally pass `fetch`.
 
 ```ts
 import {createRequester} from 'get-it'
@@ -261,7 +260,7 @@ import {createMockFetch, objectContaining} from 'get-it/mock'
 const mock = createMockFetch()
 const request = createRequester({fetch: mock.fetch, base: 'https://api.example.com'})
 
-// Register handlers — responses are one-shot by default
+// Register handlers: responses are one-shot by default
 mock.on('GET', '/api/docs', {query: {limit: '10'}}).respond({status: 200, body: {results: []}})
 
 mock
@@ -272,7 +271,9 @@ const res = await request({url: '/api/docs', query: {limit: 10}, as: 'json'})
 // res.body → {results: []}
 ```
 
-Requests are matched on method, URL (exact, glob, or predicate), query, body, and headers, with loose matching via `objectContaining()` and friends. Every request is recorded for inspection, unmatched requests throw a `MockFetchError` with a diff against the closest mock, and `get-it/vitest` adds custom matchers to vitest's `expect`:
+Requests are matched on method, URL (exact, glob, or predicate), query, body, and headers, with loose matching via `objectContaining()` and friends. Every request is recorded for inspection, and unmatched requests throw a `MockFetchError` with a diff against the closest mock.
+
+`get-it/vitest` adds custom matchers to vitest's `expect`:
 
 ```ts
 // In your test setup file (wired via vitest's setupFiles)
@@ -300,7 +301,7 @@ See [docs/mock.md](docs/mock.md) for the full documentation: response sequences 
 
 ## Migrating from v8
 
-See [docs/MIGRATION-v9.md](docs/MIGRATION-v9.md) for a comprehensive migration guide. It doubles as a playbook for AI agents: point yours at the guide and ask it to migrate the codebase.
+See [docs/MIGRATION-v9.md](docs/MIGRATION-v9.md) for the full migration guide. It doubles as a playbook for AI agents: point yours at the guide and ask it to migrate the codebase.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # get-it
 
-[![npm stat](https://img.shields.io/npm/dm/get-it.svg?style=flat-square)](https://npm-stat.com/charts.html?package=get-it)
-[![npm version](https://img.shields.io/npm/v/get-it.svg?style=flat-square)](https://www.npmjs.com/package/get-it)
-[![gzip size][gzip-badge]][bundlephobia]
-[![size][size-badge]][bundlephobia]
+[![Open on npmx.dev](https://npmx.dev/api/registry/badge/downloads-month/get-it)](https://npmx.dev/package/get-it)
+[![Latest version](https://npmx.dev/api/registry/badge/version/get-it)](https://npmx.dev/package/get-it)
+[![Pre-gzip size](https://npmx.dev/api/registry/badge/size/get-it)](https://npmx.dev/package/get-it)
+[![Number of dependencies](https://npmx.dev/api/registry/badge/dependencies/get-it)](https://npmx.dev/package/get-it)
+[![Node versions supported](https://npmx.dev/api/registry/badge/engines/get-it)](https://npmx.dev/package/get-it)
 
-Generic HTTP request library for Node.js (>= 22.12), browsers, Deno, Bun, and edge runtimes. Built on `fetch()`.
+Generic HTTP request library for Node.js (>= 22.12), browsers, Deno, Bun, and edge runtimes. It is built on `fetch()`.
 
 ## Features
 
@@ -13,8 +14,8 @@ Generic HTTP request library for Node.js (>= 22.12), browsers, Deno, Bun, and ed
 - Automatic JSON serialization/deserialization
 - Base URL and default headers
 - HTTP error throwing (on by default)
-- Timeout via `AbortSignal.timeout()`
-- Cancellation via standard `AbortController`
+- Timeout with `AbortSignal.timeout()`
+- Cancellation with the standard `AbortController`
 - Proxy support in Node.js, Bun, and Deno (reads `HTTP_PROXY`/`HTTPS_PROXY` from environment)
 - Middleware system for retry, debug logging, and custom logic
 - Injectable `fetch` for testing and custom transports
@@ -105,12 +106,12 @@ file.body // ReadableStream<Uint8Array>
 | `as`          | `'json' \| 'text' \| 'stream'`                             | Response body type                                             |
 | `signal`      | `AbortSignal`                                              | Cancellation signal                                            |
 | `httpErrors`  | `boolean`                                                  | Override instance setting                                      |
-| `timeout`     | `number \| false \| TimeoutOptions`                        | Override instance timeout (replaces it wholesale)              |
+| `timeout`     | `number \| false \| TimeoutOptions`                        | Override the instance timeout (it replaces all of it)          |
 | `fetch`       | `FetchFunction`                                            | Override instance fetch                                        |
 | `redirect`    | `'error' \| 'follow' \| 'manual'`                          | Redirect strategy (`'manual'` is opaque in browsers, see note) |
 | `credentials` | `'include' \| 'omit' \| 'same-origin'`                     | Credentials mode (browser-only)                                |
 
-> **Note on `redirect: 'manual'`:** In browsers this yields an opaque-redirect response (status `0`, empty headers) per the Fetch spec, so the 3xx status and headers (such as `location`) are unreadable. Reading them neither throws nor warns: `headers.get()` returns `null` and iteration is empty. Detect the case via `status === 0`. Non-browser runtimes (Node.js, Bun, Deno, edge runtimes, workers) return the real 3xx response, so its status and headers are readable.
+> **Note on `redirect: 'manual'`:** In browsers, the Fetch spec gives an opaque-redirect response (status `0`, empty headers). You cannot read the 3xx status or the headers, such as `location`. A read does not throw and does not warn. `headers.get()` returns `null`, and iteration gives nothing. To detect this case, test for `status === 0`. Other runtimes (Node.js, Bun, Deno, edge runtimes, workers) return the real 3xx response, and you can read its status and headers.
 
 ## Timeouts
 
@@ -125,14 +126,14 @@ const request = createRequester({
 })
 ```
 
-- `total`: the deadline you get when passing a plain number. Covers everything, including the body stream in `as: 'stream'` mode. Rejects with a `TimeoutError` DOMException, which the `retry()` middleware never retries. Combined with the retry() middleware, the deadline applies per attempt, so each retry gets a fresh total timer.
-- `headers`: time to receive response headers for one fetch attempt. Does not cover body download. Rejects with get-it's `TimeoutError` (`code: 'ETIMEDOUT'`, `phase: 'headers'`), which the default `retry()` middleware retries on GET/HEAD. The timer lives inside the middleware chain, so each retry attempt gets a fresh timer and there are no middleware ordering requirements.
+- `total`: the deadline that a plain number gives you. It covers all of the request, and it includes the body stream in `as: 'stream'` mode. It rejects with a `TimeoutError` DOMException. The `retry()` middleware never retries this error. With the `retry()` middleware, the deadline applies to each attempt. Each retry gets a new total timer.
+- `headers`: the time to receive the response headers for one fetch attempt. It does not cover the body download. It rejects with the `TimeoutError` of get-it (`code: 'ETIMEDOUT'`, `phase: 'headers'`). The default `retry()` middleware retries this error on GET and HEAD. The timer is inside the middleware chain, so each attempt gets a new timer. There are no requirements for the order of the middleware.
 
 ### Escape hatch: rejection-only timeouts (`signal: false`)
 
-By default, timeouts attach an abort signal to the fetch init. Keep it that way unless an environment forces your hand. Next.js is the one known case: its patched fetch treats any signal-carrying request as opted out of React Request Memoization, so RSC consumers would otherwise have to choose between timeouts and memoization. For that situation, `timeout: {total: 30_000, signal: false}` keeps both `total` and `headers` as pure rejections. The request promise still rejects with the same errors at the deadline, but nothing is attached to the fetch init.
+By default, a timeout attaches an abort signal to the fetch init. Keep this default unless your environment prevents it. Next.js is the one known case. Its patched fetch reads a request with a signal as a request that does not use React Request Memoization. Without this option, users of RSC must choose between timeouts and memoization. For that case, `timeout: {total: 30_000, signal: false}` makes both `total` and `headers` reject only. The request promise rejects with the same errors at the deadline, but get-it attaches nothing to the fetch init.
 
-When a timeout wins, the underlying request is not torn down: it keeps running to completion in the background, holding its connection until the server finishes on its own. A caller-provided `signal` is passed through untouched and still aborts. In `as: 'stream'` mode, `total` only covers up to response headers, since a stream already handed to you cannot be retracted.
+This option has a cost. When a timeout occurs, get-it does not stop the request. The request continues in the background and holds its connection until the server completes it. A `signal` from the caller stays unchanged and still aborts the request. In `as: 'stream'` mode, `total` covers only the time up to the response headers, because get-it cannot retract a stream that you already have.
 
 For long-running streaming downloads, disable the total deadline and keep a headers timeout:
 
@@ -173,13 +174,13 @@ const promise = request({url: '/slow', signal: controller.signal})
 controller.abort()
 ```
 
-Timeout and user-provided signals are combined automatically with `AbortSignal.any()`. The exception is rejection-only timeouts (`timeout: {signal: false}`), where the user-provided signal is passed through as-is.
+get-it combines the timeout signal and your signal automatically with `AbortSignal.any()`. Rejection-only timeouts (`timeout: {signal: false}`) are the exception. For these, get-it sends your signal without a change.
 
 ## Middleware
 
-Two types of middleware, passed in the `middleware` array:
+There are two types of middleware. You pass both types in the `middleware` array.
 
-**Transform middleware** (object). Flat pipeline, invisible in stack traces:
+**Transform middleware** (object). A flat pipeline. It is not visible in stack traces.
 
 ```ts
 const addHeader: TransformMiddleware = {
@@ -192,7 +193,7 @@ const addHeader: TransformMiddleware = {
 }
 ```
 
-**Wrapping middleware** (function). Wraps the fetch call, appears in stack traces:
+**Wrapping middleware** (function). It wraps the fetch call, and it is visible in stack traces.
 
 ```ts
 const logger: WrappingMiddleware = async (options, next) => {
@@ -213,7 +214,7 @@ const request = createRequester({
 })
 ```
 
-A per-request `maxRetries` option overrides the retry middleware's configured value for that request. Set it to `0` to disable retries.
+A `maxRetries` option on a request overrides the value in the retry middleware for that request. To disable retries, set it to `0`.
 
 ## Runtime proxy support
 
@@ -221,7 +222,7 @@ In Node.js and Bun, `createRequester` automatically uses an undici-based fetch t
 
 In Deno, `createRequester` uses Deno's built-in `fetch`, which also reads `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
 
-For custom proxy or connection pool settings:
+To set your own proxy or connection pool configuration:
 
 ```ts
 import {createRequester} from 'get-it'
@@ -236,7 +237,7 @@ const request = createRequester({
 })
 ```
 
-For explicit per-client proxy settings, custom CA certificates, or HTTP/2 settings in Deno, create a Deno `HttpClient` and inject a custom fetch:
+In Deno, you can set the proxy, the CA certificates, or HTTP/2 for each client. Create a Deno `HttpClient` and inject your own fetch:
 
 ```ts
 const client = Deno.createHttpClient({
@@ -251,7 +252,7 @@ const request = createRequester({
 
 ## Testing
 
-`get-it/mock` provides a mock fetch for testing code that uses get-it. No network, no global patching: inject `mock.fetch` where you'd normally pass `fetch`.
+`get-it/mock` gives you a mock fetch to test code that uses get-it. It uses no network and it patches no globals. Inject `mock.fetch` where you normally pass `fetch`.
 
 ```ts
 import {createRequester} from 'get-it'
@@ -271,12 +272,12 @@ const res = await request({url: '/api/docs', query: {limit: 10}, as: 'json'})
 // res.body → {results: []}
 ```
 
-Requests are matched on method, URL (exact, glob, or predicate), query, body, and headers, with loose matching via `objectContaining()` and friends. Every request is recorded for inspection, and unmatched requests throw a `MockFetchError` with a diff against the closest mock.
+The mock matches requests on the method, the URL (exact, glob, or predicate), the query, the body, and the headers. For loose matching, use `objectContaining()` and the related matchers. The mock records every request. A request that matches no mock throws a `MockFetchError` with a diff against the closest mock.
 
 `get-it/vitest` adds custom matchers to vitest's `expect`:
 
 ```ts
-// In your test setup file (wired via vitest's setupFiles)
+// In your test setup file (added through the setupFiles option of vitest)
 import 'get-it/vitest'
 ```
 
@@ -287,32 +288,29 @@ expect(mock).toHaveReceivedRequest('POST', '/api/docs', {
 expect(mock).toHaveConsumedAllMocks()
 ```
 
-See [docs/mock.md](docs/mock.md) for the full documentation: response sequences and persistent mocks, network errors, delayed and streaming response bodies (`streamBody()`), scoped mocks for multi-host code, request recording, value matchers, and the complete vitest matcher reference.
+For the full documentation, read [docs/mock.md](docs/mock.md). It covers response sequences, persistent mocks, network errors, and delayed and streaming response bodies (`streamBody()`). It also covers scoped mocks for code that uses more than one host, request recording, value matchers, and all of the vitest matchers.
 
 ## Entry points
 
-| Import              | Purpose                                                  |
-| ------------------- | -------------------------------------------------------- |
-| `get-it`            | Core (auto-selects Node variant via conditional exports) |
-| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`  |
-| `get-it/node`       | `createNodeFetch()` for custom undici dispatcher config  |
-| `get-it/mock`       | `createMockFetch()` and matchers for testing             |
-| `get-it/vitest`     | Custom vitest matchers for mock assertions               |
+| Import              | Purpose                                                     |
+| ------------------- | ----------------------------------------------------------- |
+| `get-it`            | Core (it selects the Node variant with conditional exports) |
+| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`     |
+| `get-it/node`       | `createNodeFetch()` for your own undici dispatcher          |
+| `get-it/mock`       | `createMockFetch()` and matchers for testing                |
+| `get-it/vitest`     | Custom vitest matchers for mock assertions                  |
 
 ## Migrating from v8
 
-See [docs/MIGRATION-v9.md](docs/MIGRATION-v9.md) for the full migration guide. It doubles as a playbook for AI agents: point yours at the guide and ask it to migrate the codebase.
+For the full migration guide, read [docs/MIGRATION-v9.md](docs/MIGRATION-v9.md). The guide is also a playbook for AI agents. Point your agent at the guide and tell it to migrate the codebase.
+
+## Contributing
+
+We welcome contributions. [CONTRIBUTING.md](CONTRIBUTING.md) covers the development setup, the rules for dependencies and bundle size, and how pull requests and releases work.
 
 ## License
 
 MIT-licensed. See LICENSE.
-
-## Release new version
-
-Run the ["CI & Release" workflow](https://github.com/sanity-io/get-it/actions).
-Make sure to select the main branch and check "Release new version".
-
-Semantic release will only release on configured branches, so it is safe to run release on any branch.
 
 [gzip-badge]: https://img.shields.io/bundlephobia/minzip/get-it?label=gzip%20size&style=flat-square
 [size-badge]: https://img.shields.io/bundlephobia/min/get-it?label=size&style=flat-square

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -59,13 +59,13 @@ v9 is ESM-only. If your project uses CommonJS, you'll need to either:
 
 ### `remoteAddress` removed from responses
 
-v8.7.0 added `response.remoteAddress` containing the server's IP address, obtained from Node's `http` socket. v9 uses `fetch()` which does not expose socket-level information. There is no equivalent and no workaround — this field is no longer available.
+v8.7.0 added `response.remoteAddress` containing the server's IP address, obtained from Node's `http` socket. v9 uses `fetch()` which does not expose socket-level information. There is no equivalent and no workaround.
 
 ### No redirect limit control
 
 v8 used `follow-redirects` which supported a `maxRedirects` option (defaulting to 5). v9 uses `fetch()` which follows redirects automatically with no way to limit the count. The `redirect` option on fetch only supports `'follow'` (default), `'error'` (reject on any redirect), or `'manual'` (don't follow, return the 3xx response).
 
-If you need to block redirects entirely, pass `redirect: 'error'` or `redirect: 'manual'` in the fetch init. There is no way to allow _some_ redirects but cap the count — fetch does not expose this.
+If you need to block redirects entirely, pass `redirect: 'error'` or `redirect: 'manual'` in the fetch init. There is no way to allow _some_ redirects but cap the count: fetch does not expose it.
 
 ### Retry middleware: changed set of retryable errors
 
@@ -113,7 +113,7 @@ v8 allowed all retry settings on individual requests:
 await request({url: '/critical', maxRetries: 10, shouldRetry: customPredicate})
 ```
 
-v9 keeps per-request `maxRetries` — it overrides the middleware's configured value for that request, in both directions:
+v9 keeps per-request `maxRetries`. It overrides the middleware's configured value for that request, in both directions:
 
 ```ts
 // v9
@@ -188,7 +188,7 @@ v8 expanded arrays into repeated keys: `{tags: ['a', 'b']}` → `tags=a&tags=b`.
 await request({url: '/api', query: {tags: ['a', 'b']}})
 // → /api?tags=a&tags=b
 
-// v9 — WRONG, produces /api?tags=a%2Cb
+// v9: WRONG, produces /api?tags=a%2Cb
 await request({url: '/api', query: {tags: ['a', 'b']}})
 ```
 
@@ -221,18 +221,18 @@ The mapping:
 | `withCredentials: false` | `credentials: 'omit'`                          |
 | _(not set)_              | `credentials: 'same-origin'` (browser default) |
 
-Note: `credentials` follows the fetch API and is forwarded whenever you set it, including in browser workers and edge runtimes.
+`credentials` follows the fetch API and is forwarded whenever you set it, including in browser workers and edge runtimes.
 
 ### `fetch` option changed meaning
 
 v8's `fetch` option on request options was a `boolean | Omit<RequestInit, 'method'>` that opted into using the native `fetch` API instead of Node's `http`/`https` modules, and could pass through `RequestInit` options like `cache`:
 
 ```ts
-// v8 — opt into native fetch with cache control
+// v8: opt into native fetch with cache control
 await request({url: '/api', fetch: {cache: 'no-store'}})
 ```
 
-In v9, `fetch` is always used (there is no `http`/`https` transport), and the `fetch` option on both `RequesterOptions` and `RequestOptions` is a `FetchFunction` — an injectable fetch implementation, not a config flag.
+In v9, `fetch` is always used (there is no `http`/`https` transport), and the `fetch` option on both `RequesterOptions` and `RequestOptions` is a `FetchFunction`, an injectable fetch implementation rather than a config flag.
 
 To pass `RequestInit` options like `cache`, wrap the global fetch:
 
@@ -244,7 +244,7 @@ const request = createRequester({
 
 ### `clone()` removed
 
-v8 had `request.clone()` to create derived requesters that inherited the parent's middleware stack. v9 has no `clone()` — since `createRequester` takes a plain options object, you get the same result by spreading shared config:
+v8 had `request.clone()` to create derived requesters that inherited the parent's middleware stack. v9 has no `clone()`. Since `createRequester` takes a plain options object, you get the same result by spreading shared config:
 
 ```ts
 // v8
@@ -266,7 +266,7 @@ const withAuth = createRequester({
 
 ### `onlyBody` removed
 
-v8's `promise({ onlyBody: true })` resolved with just the response body instead of the full response object. v9 always resolves with the full response — access the body directly:
+v8's `promise({ onlyBody: true })` resolved with just the response body instead of the full response object. v9 always resolves with the full response. Access the body directly:
 
 ```ts
 // v8
@@ -279,7 +279,7 @@ const body = res.body
 
 ### `compress` removed
 
-v8 supported a `compress` option (defaulting to `true`) that sent `accept-encoding: gzip, deflate` headers. In v9, fetch handles content negotiation automatically — there is no option to disable it.
+v8 supported a `compress` option (defaulting to `true`) that sent `accept-encoding: gzip, deflate` headers. In v9, fetch handles content negotiation automatically, and there is no option to disable it.
 
 ## Creating a request instance
 
@@ -307,7 +307,7 @@ import {createRequester} from 'get-it'
 const request = createRequester({
   base: 'https://api.example.com',
   headers: {Authorization: 'Bearer ...'},
-  // JSON serialization, HTTP errors, and promise-based — all built in
+  // JSON serialization, HTTP errors, and promise-based: all built in
 })
 ```
 
@@ -412,7 +412,7 @@ const res = request({url: '/users', signal: controller.signal})
 controller.abort()
 ```
 
-Standard `AbortController` — no custom cancellation primitives.
+Standard `AbortController`, with no custom cancellation primitives.
 
 ## HTTP errors
 
@@ -485,7 +485,7 @@ await request({url: '/slow', timeout: {headers: 5000}})
 
 | v8                   | v9                                                                                                                                                             |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `timeout: {connect}` | `timeout: {headers}` — per-attempt time to response headers, throws a retryable `TimeoutError`                                                                 |
+| `timeout: {connect}` | `timeout: {headers}`. Per-attempt time to response headers, throws a retryable `TimeoutError`                                                                  |
 | `timeout: {socket}`  | No direct equivalent (no idle/stall detection). Use `total` as a blunt substitute (note: per retry attempt when combined with `retry()`), or watch the stream. |
 
 For streaming downloads that should never hit a total deadline but fail fast on unresponsive servers:
@@ -513,7 +513,7 @@ v9 has two middleware types instead of the v8 hook-based system:
 
 ### Transform middleware (object with hooks)
 
-Flat pipeline — does not wrap the fetch call, invisible in stack traces:
+Flat pipeline. Does not wrap the fetch call, invisible in stack traces:
 
 ```ts
 import type {TransformMiddleware} from 'get-it'
@@ -532,7 +532,7 @@ const myTransform: TransformMiddleware = {
 
 ### Wrapping middleware (function)
 
-Wraps the fetch call — appears in stack traces. Used for retry, error recovery:
+Wraps the fetch call and appears in stack traces. Used for retry and error recovery:
 
 ```ts
 import type {WrappingMiddleware} from 'get-it'
@@ -558,14 +558,14 @@ const request = createRequester({
 })
 ```
 
-Note: v8's `requester.use(middleware)` chaining is removed. Pass all middleware at creation time.
+v8's `requester.use(middleware)` chaining is removed. Pass all middleware at creation time.
 
 ### Custom per-request properties (`meta`)
 
 v8 allowed custom properties directly on the request options object. Middleware could access them via `processOptions`:
 
 ```ts
-// v8 — custom properties on RequestOptions
+// v8: custom properties on RequestOptions
 const request = getIt([
   {
     processOptions: (opts) => {
@@ -580,10 +580,10 @@ const request = getIt([
 await request({url: '/api', lineage: 'abc'})
 ```
 
-v9's `RequestOptions` is a closed type — unknown properties are rejected by TypeScript. Use the `meta` field instead, which is typed as `Record<string, unknown>`:
+v9's `RequestOptions` is a closed type: unknown properties are rejected by TypeScript. Use the `meta` field instead, which is typed as `Record<string, unknown>`:
 
 ```ts
-// v9 — use meta for custom per-request data
+// v9: use meta for custom per-request data
 const request = createRequester({
   middleware: [
     {
@@ -609,19 +609,19 @@ The `meta` field is passed through to all middleware (both transform and wrappin
 
 ### Removed middleware (no replacement needed)
 
-| Middleware         | Reason                                                                          |
-| ------------------ | ------------------------------------------------------------------------------- |
-| `promise()`        | All requests return promises by default                                         |
-| `jsonRequest()`    | Built in — plain objects and arrays are auto-serialized as JSON                 |
-| `jsonResponse()`   | Use `as: 'json'` or `res.json()`                                                |
-| `httpErrors()`     | Built in, on by default                                                         |
-| `base(url)`        | Use `createRequester({ base: url })`                                            |
-| `headers(obj)`     | Use `createRequester({ headers: obj })`                                         |
-| `observable()`     | Wrap with RxJS `defer(() => promise)` (cold) or `from(promise)` (eager)         |
-| `progress()`       | Removed — no replacement in fetch-based architecture                            |
-| `keepAlive()`      | Built into fetch connection pooling                                             |
-| `injectResponse()` | Removed — use injectable `fetch` for testing                                    |
-| `urlEncoded()`     | Pass `new URLSearchParams(...)` as body — fetch sets content-type automatically |
+| Middleware         | Reason                                                                         |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `promise()`        | All requests return promises by default                                        |
+| `jsonRequest()`    | Built in. Plain objects and arrays are auto-serialized as JSON                 |
+| `jsonResponse()`   | Use `as: 'json'` or `res.json()`                                               |
+| `httpErrors()`     | Built in, on by default                                                        |
+| `base(url)`        | Use `createRequester({ base: url })`                                           |
+| `headers(obj)`     | Use `createRequester({ headers: obj })`                                        |
+| `observable()`     | Wrap with RxJS `defer(() => promise)` (cold) or `from(promise)` (eager)        |
+| `progress()`       | Removed, no replacement in the fetch-based architecture                        |
+| `keepAlive()`      | Built into fetch connection pooling                                            |
+| `injectResponse()` | Removed. Use injectable `fetch`, or `get-it/mock`, for testing                 |
+| `urlEncoded()`     | Pass `new URLSearchParams(...)` as body; fetch sets content-type automatically |
 
 ### Still available
 
@@ -632,18 +632,18 @@ The `meta` field is passed through to all middleware (both transform and wrappin
 
 ### Debug middleware changes
 
-v8's `debug()` middleware used the [`debug`](https://www.npmjs.com/package/debug) npm package, enabled with the `DEBUG=get-it:*` environment variable — zero config, no code changes needed.
+v8's `debug()` middleware used the [`debug`](https://www.npmjs.com/package/debug) npm package, enabled with the `DEBUG=get-it:*` environment variable. Zero config, no code changes needed.
 
 v9's `debug()` requires an explicit `log` function. Without one, it's a no-op:
 
 ```ts
 import {debug} from 'get-it/middleware'
 
-// v8 — just add the middleware, control via DEBUG env var
+// v8: add the middleware, control via DEBUG env var
 const request = getIt([debug()])
 // $ DEBUG=get-it:* node app.js
 
-// v9 — must pass a log function explicitly
+// v9: must pass a log function explicitly
 const request = createRequester({
   middleware: [debug({log: console.log, verbose: true})],
 })
@@ -671,10 +671,7 @@ request({url: '/users', requestId: 'abc-123'})
 request({url: '/users', meta: {requestId: 'abc-123'}})
 ```
 
-**What's different from v8:**
-
-- **Activation**: v8 used the `DEBUG=get-it:*` env var automatically. v9 requires an explicit `log` function (see above for restoring env var behavior).
-- **Body truncation**: v9 truncates logged bodies at 16 KB and summarizes binary/stream bodies, preventing large payloads from flooding logs.
+One other difference: v9 truncates logged bodies at 16 KB and summarizes binary and stream bodies, so large payloads no longer flood the logs.
 
 ### Proxy / agent configuration
 
@@ -717,7 +714,7 @@ const request = createRequester({
 v9 lets you provide a custom `fetch` implementation at instance or request level:
 
 ```ts
-// Instance level — used for all requests
+// Instance level: used for all requests
 const request = createRequester({fetch: myCustomFetch})
 
 // Per-request override
@@ -755,15 +752,17 @@ beforeRequest(opts) {
 }
 ```
 
-Use **lowercase header names** in middleware — since all keys are normalized to lowercase, using a different casing (e.g. `'Content-Type'` when `'content-type'` already exists) would create a duplicate entry rather than overriding it.
+Use **lowercase header names** in middleware. All keys are normalized to lowercase, so a different casing (`'Content-Type'` when `'content-type'` already exists) creates a duplicate entry rather than overriding it.
 
 ## Entry points
 
 | Import              | Purpose                                                          |
 | ------------------- | ---------------------------------------------------------------- |
 | `get-it`            | Core. Includes environment proxy support in Node, Bun, and Deno. |
-| `get-it/middleware` | `retry`, `debug`                                                 |
+| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`          |
 | `get-it/node`       | `createNodeFetch()` for custom undici dispatcher configuration   |
+| `get-it/mock`       | `createMockFetch()` and matchers, replacing `injectResponse()`   |
+| `get-it/vitest`     | Custom vitest matchers for mock assertions                       |
 
 ## TypeScript
 
@@ -856,7 +855,7 @@ const request = createRequester({
 const response = await request<User[]>({url: '/users', as: 'json'})
 const users = response.body
 
-// Observable — wrap the promise yourself
+// Observable: wrap the promise yourself
 // Use `defer` so the request fires on subscribe (cold), matching v8's
 // `observable()`. Plain `from(request('/users'))` would fire eagerly.
 import {defer} from 'rxjs'

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -1,16 +1,22 @@
 # Migrating from get-it v8 to v9
 
-get-it v9 is a ground-up rewrite. It replaces the pub/sub channel system and Node `http`/`https` transport with standard `fetch()`, drops CommonJS, and simplifies the API surface.
+get-it v9 is a full rewrite. It replaces the pub/sub channel system and the Node `http`/`https` transport with the standard `fetch()`. It also removes CommonJS and makes the API smaller.
 
 This guide covers every breaking change and shows how to update your code.
 
 ## Migrating with an AI agent
 
-This guide also works as a playbook for a coding agent. Point yours at it and have it work through the whole document, not just the quick reference. A reliable approach:
+This guide is also a playbook for a coding agent. Point your agent at the full document, not only at the quick reference. Use this sequence:
 
-1. Search the codebase for every v8 pattern: `getIt(`, `from 'get-it'`, `require('get-it')`, `.use(`, `.clone()`, `statusCode`, `statusMessage`, bracket-notation header access, `.body`, `CancelToken` / `cancelToken` / `isCancel`, `withCredentials`, `requestId`, `stream: true`, `rawBody`, `onlyBody`, `compress`, and the removed middleware (`promise`, `jsonRequest`, `jsonResponse`, `httpErrors`, `base`, `headers`, `observable`, `progress`, `keepAlive`, `agent`, `proxy`, `urlEncoded`).
+1. Search the codebase for these v8 patterns:
+   - `getIt(`, `from 'get-it'`, `require('get-it')`, `.use(`, `.clone()`
+   - `statusCode`, `statusMessage`, `.body`, and bracket-notation header access
+   - `CancelToken`, `cancelToken`, `isCancel`, `withCredentials`, `requestId`
+   - `stream: true`, `rawBody`, `onlyBody`, `compress`
+   - the removed middleware: `promise`, `jsonRequest`, `jsonResponse`, `httpErrors`, `base`, `headers`, `observable`, `progress`, `keepAlive`, `agent`, `proxy`, `urlEncoded`
 2. Apply the mappings from the sections below to each match.
-3. Verify: run `tsc --noEmit`, run the test suite, then re-check for leftover `statusCode`, bracket-notation header access, `CancelToken` remnants, and custom request properties that need moving to `meta`.
+3. Run `tsc --noEmit`, then run the test suite.
+4. Search again for `statusCode`, bracket-notation header access, `CancelToken`, and custom request properties. Move the custom properties to `meta`.
 
 ## Quick reference
 
@@ -34,7 +40,7 @@ This guide also works as a playbook for a coding agent. Point yours at it and ha
 | `progress()` middleware         | removed, no replacement                            |
 | `keepAlive()` middleware        | built into fetch                                   |
 | `agent(opts)` middleware        | `createNodeFetch(opts)` or injectable `fetch`      |
-| `proxy(opts)` middleware        | automatic via conditional exports                  |
+| `proxy(opts)` middleware        | automatic, with conditional exports                |
 | `mtls(opts)` middleware         | `createNodeFetch({ tls: { cert, key, ca } })`      |
 | `bodySize: N`                   | `headers: {'content-length': N}`                   |
 | `compress: false`               | removed (fetch always negotiates compression)      |
@@ -50,28 +56,28 @@ This guide also works as a playbook for a coding agent. Point yours at it and ha
 npm install get-it@^9
 ```
 
-v9 is ESM-only. If your project uses CommonJS, you'll need to either:
+v9 is ESM-only. If your project uses CommonJS, do one of these:
 
-- Switch to ESM (`"type": "module"` in package.json)
-- Use dynamic `import()` from CommonJS
+- Change the project to ESM (`"type": "module"` in package.json)
+- Use a dynamic `import()` from CommonJS
 
 ## Behavioral changes
 
 ### `remoteAddress` removed from responses
 
-v8.7.0 added `response.remoteAddress` containing the server's IP address, obtained from Node's `http` socket. v9 uses `fetch()` which does not expose socket-level information. There is no equivalent and no workaround.
+v8.7.0 added `response.remoteAddress`. This field held the IP address of the server, from the `http` socket of Node. v9 uses `fetch()`, which does not expose socket-level data. There is no equivalent and no workaround.
 
 ### No redirect limit control
 
-v8 used `follow-redirects` which supported a `maxRedirects` option (defaulting to 5). v9 uses `fetch()` which follows redirects automatically with no way to limit the count. The `redirect` option on fetch only supports `'follow'` (default), `'error'` (reject on any redirect), or `'manual'` (don't follow, return the 3xx response).
+v8 used `follow-redirects`, which supported a `maxRedirects` option with a default of 5. v9 uses `fetch()`, which follows redirects automatically. You cannot limit the count. The `redirect` option on fetch supports `'follow'` (the default), `'error'` (reject on any redirect), and `'manual'` (do not follow, return the 3xx response).
 
-If you need to block redirects entirely, pass `redirect: 'error'` or `redirect: 'manual'` in the fetch init. There is no way to allow _some_ redirects but cap the count: fetch does not expose it.
+To block all redirects, pass `redirect: 'error'` or `redirect: 'manual'` in the fetch init. You cannot allow _some_ redirects and limit the count, because fetch does not expose this control.
 
 ### Retry middleware: changed set of retryable errors
 
-v8's retry middleware treated `ENOTFOUND` and `ENETUNREACH` as non-retryable. v9 retries `ENOTFOUND` (DNS resolution failure) because transient DNS failures on valid hostnames can surface as `ENOTFOUND` rather than `EAI_AGAIN`. `ENETUNREACH` (no route to host) remains non-retryable since it indicates a routing or network interface problem that won't resolve on retry.
+The retry middleware of v8 treated `ENOTFOUND` and `ENETUNREACH` as non-retryable. v9 retries `ENOTFOUND` (a DNS resolution failure), because a temporary DNS failure on a valid hostname can give `ENOTFOUND` and not `EAI_AGAIN`. `ENETUNREACH` (no route to host) stays non-retryable. This code shows a routing error or a network interface error, and a retry cannot correct it.
 
-The full set of retryable error codes in v9:
+These are the retryable error codes in v9:
 
 | Retried                   | Not retried   |
 | ------------------------- | ------------- |
@@ -86,7 +92,7 @@ The full set of retryable error codes in v9:
 | `UND_ERR_CONNECT_TIMEOUT` |               |
 | `UND_ERR_SOCKET`          |               |
 
-To restore v8 behavior, provide a custom `shouldRetry`:
+To get the v8 behavior again, supply your own `shouldRetry`:
 
 ```ts
 import {retry} from 'get-it/middleware'
@@ -106,14 +112,14 @@ const request = createRequester({
 
 ### Per-request retry overrides limited to `maxRetries`
 
-v8 allowed all retry settings on individual requests:
+v8 permitted all retry options on an individual request:
 
 ```ts
 // v8
 await request({url: '/critical', maxRetries: 10, shouldRetry: customPredicate})
 ```
 
-v9 keeps per-request `maxRetries`. It overrides the middleware's configured value for that request, in both directions:
+v9 keeps `maxRetries` on a request. It overrides the value in the middleware for that request, and it can increase or decrease the value:
 
 ```ts
 // v9
@@ -121,7 +127,7 @@ await request({url: '/critical', maxRetries: 10})
 await request({url: '/no-retries', maxRetries: 0})
 ```
 
-`retryDelay` and `shouldRetry` are set once when creating the middleware. To use different values for different requests, create separate request instances:
+You set `retryDelay` and `shouldRetry` one time, when you create the middleware. To use different values for different requests, create separate request instances:
 
 ```ts
 // v9
@@ -138,7 +144,7 @@ const criticalRequest = createRequester({
 })
 ```
 
-Alternatively, use `meta` to pass hints and a custom `shouldRetry` that reads them:
+As an alternative, use `meta` to pass hints, with your own `shouldRetry` that reads them:
 
 ```ts
 const request = createRequester({
@@ -155,7 +161,7 @@ const request = createRequester({
 await request({url: '/critical', meta: {maxRetries: 10}})
 ```
 
-v9 exports the default retry helpers so you can extend them instead of rewriting from scratch:
+v9 exports the default retry helpers. You can extend them, and you do not have to write new ones:
 
 ```ts
 import {retry, isRetryableRequest, getRetryDelay} from 'get-it/middleware'
@@ -181,7 +187,7 @@ const request = createRequester({
 
 ### Query parameters no longer accept arrays
 
-v8 expanded arrays into repeated keys: `{tags: ['a', 'b']}` → `tags=a&tags=b`. v9's `query` option only accepts scalar values (`string | number | boolean | undefined`). Passing an array will silently produce a single comma-joined value via `String()`:
+v8 expanded an array into repeated keys: `{tags: ['a', 'b']}` → `tags=a&tags=b`. The `query` option of v9 accepts only scalar values (`string | number | boolean | undefined`). If you pass an array, `String()` gives one comma-joined value, with no warning:
 
 ```ts
 // v8
@@ -203,7 +209,7 @@ await request({url: '/api', query: params})
 
 ### `withCredentials` replaced by `credentials`
 
-v8 used the XHR-style boolean `withCredentials: true` to send cookies cross-origin. v9 uses the fetch-style `credentials` option:
+v8 used the XHR-style boolean `withCredentials: true` to send cookies to a different origin. v9 uses the fetch-style `credentials` option:
 
 ```ts
 // v8
@@ -221,20 +227,20 @@ The mapping:
 | `withCredentials: false` | `credentials: 'omit'`                          |
 | _(not set)_              | `credentials: 'same-origin'` (browser default) |
 
-`credentials` follows the fetch API and is forwarded whenever you set it, including in browser workers and edge runtimes.
+`credentials` obeys the fetch API. get-it sends it each time that you set it, and it does the same in browser workers and edge runtimes.
 
 ### `fetch` option changed meaning
 
-v8's `fetch` option on request options was a `boolean | Omit<RequestInit, 'method'>` that opted into using the native `fetch` API instead of Node's `http`/`https` modules, and could pass through `RequestInit` options like `cache`:
+In v8, the `fetch` option on the request options was a `boolean | Omit<RequestInit, 'method'>`. It selected the native `fetch` API in place of the `http` and `https` modules of Node. It also sent `RequestInit` options such as `cache`:
 
 ```ts
 // v8: opt into native fetch with cache control
 await request({url: '/api', fetch: {cache: 'no-store'}})
 ```
 
-In v9, `fetch` is always used (there is no `http`/`https` transport), and the `fetch` option on both `RequesterOptions` and `RequestOptions` is a `FetchFunction`, an injectable fetch implementation rather than a config flag.
+v9 always uses `fetch`, because there is no `http` or `https` transport. On both `RequesterOptions` and `RequestOptions`, the `fetch` option is now a `FetchFunction`. It is an injectable fetch implementation, not a flag.
 
-To pass `RequestInit` options like `cache`, wrap the global fetch:
+To pass `RequestInit` options such as `cache`, wrap the global fetch:
 
 ```ts
 const request = createRequester({
@@ -244,7 +250,7 @@ const request = createRequester({
 
 ### `clone()` removed
 
-v8 had `request.clone()` to create derived requesters that inherited the parent's middleware stack. v9 has no `clone()`. Since `createRequester` takes a plain options object, you get the same result by spreading shared config:
+v8 had `request.clone()`. It created derived requesters that inherited the middleware stack of the parent. v9 has no `clone()`. `createRequester` takes a plain options object, so you get the same result when you spread a shared configuration:
 
 ```ts
 // v8
@@ -266,7 +272,7 @@ const withAuth = createRequester({
 
 ### `onlyBody` removed
 
-v8's `promise({ onlyBody: true })` resolved with just the response body instead of the full response object. v9 always resolves with the full response. Access the body directly:
+In v8, `promise({ onlyBody: true })` resolved with the response body only, and not with the full response object. v9 always resolves with the full response. Read the body directly:
 
 ```ts
 // v8
@@ -279,7 +285,7 @@ const body = res.body
 
 ### `compress` removed
 
-v8 supported a `compress` option (defaulting to `true`) that sent `accept-encoding: gzip, deflate` headers. In v9, fetch handles content negotiation automatically, and there is no option to disable it.
+v8 supported a `compress` option with a default of `true`. It sent an `accept-encoding: gzip, deflate` header. In v9, fetch does the content negotiation automatically, and there is no option to disable it.
 
 ## Creating a request instance
 
@@ -311,7 +317,7 @@ const request = createRequester({
 })
 ```
 
-Base URL, default headers, JSON request serialization, HTTP error throwing, and promise return are all built into the core. You no longer need middleware for these.
+The core has the base URL, the default headers, the JSON request serialization, the HTTP error throwing, and the promise return. You no longer need middleware for these functions.
 
 ## Making requests
 
@@ -340,7 +346,7 @@ const response = await request('/users')
 
 ## Response shape changes
 
-The response object has changed:
+The response object is different:
 
 ```ts
 // v8
@@ -371,7 +377,7 @@ const contentType = response.headers.get('content-type')
 
 ## Body type selection with `as`
 
-v9 introduces the `as` option to control how the response body is processed:
+v9 adds the `as` option. It controls how get-it processes the response body:
 
 | `as` value  | `body` type                                     | Buffered? |
 | ----------- | ----------------------------------------------- | --------- |
@@ -412,7 +418,7 @@ const res = request({url: '/users', signal: controller.signal})
 controller.abort()
 ```
 
-Standard `AbortController`, with no custom cancellation primitives.
+v9 uses the standard `AbortController`. There are no custom cancellation primitives.
 
 ## HTTP errors
 
@@ -427,7 +433,7 @@ const request = getIt([httpErrors(), promise()])
 
 ### After (v9)
 
-HTTP error throwing is built in and on by default. Opt out per-instance or per-request:
+HTTP error throwing is built in, and it is on by default. You can disable it for an instance or for one request:
 
 ```ts
 // Disable for all requests
@@ -463,7 +469,7 @@ await request({url: '/slow', timeout: {connect: 5000, socket: 30000}})
 
 ### After (v9)
 
-Timeout uses `AbortSignal.timeout()`. A single value in milliseconds:
+The timeout uses `AbortSignal.timeout()`. Give one value in milliseconds:
 
 ```ts
 const request = createRequester({timeout: 30000})
@@ -475,7 +481,7 @@ await request({url: '/slow', timeout: 5000})
 await request({url: '/slow', timeout: false})
 ```
 
-Since v9.2, `timeout` also accepts a structured object for finer control:
+From v9.2, `timeout` also accepts a structured object for more control:
 
 ```ts
 // v8: timeout: {connect: 5000, socket: 30000}
@@ -483,12 +489,12 @@ Since v9.2, `timeout` also accepts a structured object for finer control:
 await request({url: '/slow', timeout: {headers: 5000}})
 ```
 
-| v8                   | v9                                                                                                                                                             |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `timeout: {connect}` | `timeout: {headers}`. Per-attempt time to response headers, throws a retryable `TimeoutError`                                                                  |
-| `timeout: {socket}`  | No direct equivalent (no idle/stall detection). Use `total` as a blunt substitute (note: per retry attempt when combined with `retry()`), or watch the stream. |
+| v8                   | v9                                                                                                                                                                         |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timeout: {connect}` | `timeout: {headers}`. Per-attempt time to response headers, throws a retryable `TimeoutError`                                                                              |
+| `timeout: {socket}`  | No direct equivalent. There is no detection of an idle or stalled connection. Use `total` instead, or monitor the stream. With `retry()`, `total` applies to each attempt. |
 
-For streaming downloads that should never hit a total deadline but fail fast on unresponsive servers:
+For a streaming download that must not have a total deadline, but must fail quickly on an unresponsive server:
 
 ```ts
 import {retry} from 'get-it/middleware'
@@ -499,9 +505,9 @@ const request = createRequester({
 })
 ```
 
-The timeout signal is automatically combined with any user-provided `signal` using `AbortSignal.any()`.
+get-it combines the timeout signal and your `signal` automatically with `AbortSignal.any()`.
 
-**React Native**: v8 detected React Native (`navigator.product === 'ReactNative'`) and used a 60s default timeout. v9 uses 120s everywhere. To restore the shorter timeout:
+**React Native**: v8 detected React Native (`navigator.product === 'ReactNative'`) and used a default timeout of 60 seconds. v9 uses 120 seconds in all runtimes. To get the shorter timeout again:
 
 ```ts
 const request = createRequester({timeout: 60000})
@@ -509,11 +515,11 @@ const request = createRequester({timeout: 60000})
 
 ## Middleware
 
-v9 has two middleware types instead of the v8 hook-based system:
+v9 has two middleware types. They replace the hook-based system of v8:
 
 ### Transform middleware (object with hooks)
 
-Flat pipeline. Does not wrap the fetch call, invisible in stack traces:
+A flat pipeline. It does not wrap the fetch call, and it is not visible in stack traces:
 
 ```ts
 import type {TransformMiddleware} from 'get-it'
@@ -532,7 +538,7 @@ const myTransform: TransformMiddleware = {
 
 ### Wrapping middleware (function)
 
-Wraps the fetch call and appears in stack traces. Used for retry and error recovery:
+It wraps the fetch call and is visible in stack traces. Use it for retries and error recovery:
 
 ```ts
 import type {WrappingMiddleware} from 'get-it'
@@ -545,7 +551,7 @@ const myWrapper: WrappingMiddleware = async (options, next) => {
 }
 ```
 
-get-it distinguishes the two by shape: object = transform, function = wrapping.
+get-it identifies the two types by shape: an object is a transform middleware, and a function is a wrapping middleware.
 
 ### Passing middleware
 
@@ -558,11 +564,11 @@ const request = createRequester({
 })
 ```
 
-v8's `requester.use(middleware)` chaining is removed. Pass all middleware at creation time.
+v9 removes the `requester.use(middleware)` chain of v8. Pass all middleware when you create the requester.
 
 ### Custom per-request properties (`meta`)
 
-v8 allowed custom properties directly on the request options object. Middleware could access them via `processOptions`:
+v8 permitted custom properties directly on the request options object. Middleware read them with `processOptions`:
 
 ```ts
 // v8: custom properties on RequestOptions
@@ -580,7 +586,7 @@ const request = getIt([
 await request({url: '/api', lineage: 'abc'})
 ```
 
-v9's `RequestOptions` is a closed type: unknown properties are rejected by TypeScript. Use the `meta` field instead, which is typed as `Record<string, unknown>`:
+The `RequestOptions` of v9 is a closed type, and TypeScript rejects unknown properties. Use the `meta` field instead. Its type is `Record<string, unknown>`:
 
 ```ts
 // v9: use meta for custom per-request data
@@ -603,25 +609,25 @@ const request = createRequester({
 await request({url: '/api', meta: {lineage: 'abc'}})
 ```
 
-The `meta` field is passed through to all middleware (both transform and wrapping) but is not sent over the wire.
+get-it sends the `meta` field to all middleware, both transform and wrapping. It does not send `meta` over the wire.
 
 ## Middleware migration
 
 ### Removed middleware (no replacement needed)
 
-| Middleware         | Reason                                                                         |
-| ------------------ | ------------------------------------------------------------------------------ |
-| `promise()`        | All requests return promises by default                                        |
-| `jsonRequest()`    | Built in. Plain objects and arrays are auto-serialized as JSON                 |
-| `jsonResponse()`   | Use `as: 'json'` or `res.json()`                                               |
-| `httpErrors()`     | Built in, on by default                                                        |
-| `base(url)`        | Use `createRequester({ base: url })`                                           |
-| `headers(obj)`     | Use `createRequester({ headers: obj })`                                        |
-| `observable()`     | Wrap with RxJS `defer(() => promise)` (cold) or `from(promise)` (eager)        |
-| `progress()`       | Removed, no replacement in the fetch-based architecture                        |
-| `keepAlive()`      | Built into fetch connection pooling                                            |
-| `injectResponse()` | Removed. Use injectable `fetch`, or `get-it/mock`, for testing                 |
-| `urlEncoded()`     | Pass `new URLSearchParams(...)` as body; fetch sets content-type automatically |
+| Middleware         | Reason                                                                   |
+| ------------------ | ------------------------------------------------------------------------ |
+| `promise()`        | All requests return promises by default                                  |
+| `jsonRequest()`    | Built in. Plain objects and arrays are auto-serialized as JSON           |
+| `jsonResponse()`   | Use `as: 'json'` or `res.json()`                                         |
+| `httpErrors()`     | Built in, on by default                                                  |
+| `base(url)`        | Use `createRequester({ base: url })`                                     |
+| `headers(obj)`     | Use `createRequester({ headers: obj })`                                  |
+| `observable()`     | Wrap with RxJS `defer(() => promise)` (cold) or `from(promise)` (eager)  |
+| `progress()`       | Removed. There is no replacement in the fetch-based architecture         |
+| `keepAlive()`      | Built into fetch connection pooling                                      |
+| `injectResponse()` | Removed. Use injectable `fetch`, or `get-it/mock`, for testing           |
+| `urlEncoded()`     | Pass `new URLSearchParams(...)` as body, and fetch sets the content-type |
 
 ### Still available
 
@@ -632,9 +638,9 @@ The `meta` field is passed through to all middleware (both transform and wrappin
 
 ### Debug middleware changes
 
-v8's `debug()` middleware used the [`debug`](https://www.npmjs.com/package/debug) npm package, enabled with the `DEBUG=get-it:*` environment variable. Zero config, no code changes needed.
+The `debug()` middleware of v8 used the [`debug`](https://www.npmjs.com/package/debug) npm package. The `DEBUG=get-it:*` environment variable enabled it. It needed no configuration and no code changes.
 
-v9's `debug()` requires an explicit `log` function. Without one, it's a no-op:
+The `debug()` of v9 needs an explicit `log` function. Without this function, it does nothing:
 
 ```ts
 import {debug} from 'get-it/middleware'
@@ -649,7 +655,7 @@ const request = createRequester({
 })
 ```
 
-To restore `DEBUG` env var behavior, install the `debug` package and pass it as the log function:
+To get the `DEBUG` environment variable behavior again, install the `debug` package. Then pass it as the log function:
 
 ```ts
 import createDebug from 'debug'
@@ -661,7 +667,7 @@ const request = createRequester({
 // $ DEBUG=get-it node app.js
 ```
 
-v8 supported `requestId` as a top-level request option. In v9, pass it via `meta`:
+v8 supported `requestId` as a top-level request option. In v9, pass it in `meta`:
 
 ```ts
 // v8
@@ -671,17 +677,17 @@ request({url: '/users', requestId: 'abc-123'})
 request({url: '/users', meta: {requestId: 'abc-123'}})
 ```
 
-One other difference: v9 truncates logged bodies at 16 KB and summarizes binary and stream bodies, so large payloads no longer flood the logs.
+There is one other difference. v9 truncates a logged body at 16 KB, and it summarizes binary and stream bodies. Large payloads no longer flood the logs.
 
 ### Proxy / agent configuration
 
-v8 had `agent()` and `proxy()` middleware that configured Node's `http.Agent`.
+v8 had `agent()` and `proxy()` middleware. They configured the `http.Agent` of Node.
 
-v9 uses conditional exports: when running in Node or Bun, `createRequester` automatically uses `createNodeFetch()` which reads proxy configuration from environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`).
+v9 uses conditional exports. In Node and Bun, `createRequester` automatically uses `createNodeFetch()`. This function reads the proxy configuration from the environment variables `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
 
-In Deno, `createRequester` uses the built-in `fetch`, which also reads `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
+In Deno, `createRequester` uses the built-in `fetch`. This fetch also reads `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
 
-For custom proxy or connection pool settings:
+To set your own proxy or connection pool configuration:
 
 ```ts
 import {createRequester} from 'get-it'
@@ -696,7 +702,7 @@ const request = createRequester({
 })
 ```
 
-For explicit per-client proxy settings, CA certificates, or HTTP/2 in Deno, inject a fetch that passes a Deno `HttpClient`:
+In Deno, you can set the proxy, the CA certificates, or HTTP/2 for each client. Inject a fetch that passes a Deno `HttpClient`:
 
 ```ts
 const client = Deno.createHttpClient({
@@ -711,7 +717,7 @@ const request = createRequester({
 
 ## Injectable fetch
 
-v9 lets you provide a custom `fetch` implementation at instance or request level:
+In v9, you can supply your own `fetch` implementation for an instance or for one request:
 
 ```ts
 // Instance level: used for all requests
@@ -721,11 +727,11 @@ const request = createRequester({fetch: myCustomFetch})
 await request({url: '/test', fetch: mockFetch})
 ```
 
-This replaces v8's `injectResponse()` for testing and `agent()` for custom transports.
+This option replaces the `injectResponse()` of v8 for tests, and the `agent()` of v8 for custom transports.
 
 ## Headers
 
-v9 uses `FetchHeaders` for input and `Headers` instances internally:
+v9 accepts `FetchHeaders` as input. Internally, it uses `Headers` instances:
 
 ```ts
 // All of these work as header input:
@@ -734,7 +740,7 @@ createRequester({headers: new Headers({'X-Custom': 'value'})}) // Headers
 createRequester({headers: [['X-Custom', 'value']]}) // Tuples
 ```
 
-Per-request headers merge with instance headers (per-request wins on conflict):
+Headers on a request merge with the headers on the instance. On a conflict, the header on the request has priority:
 
 ```ts
 const request = createRequester({headers: {'X-A': '1'}})
@@ -744,7 +750,7 @@ await request({url: '/test', headers: {'X-B': '2'}})
 
 ### Headers in middleware
 
-By the time `beforeRequest` receives the options, headers have been merged into a plain `Record<string, string>` with lowercase keys. This means spreading works naturally:
+Before `beforeRequest` receives the options, get-it merges the headers into a plain `Record<string, string>` with lowercase keys. Thus you can spread the object:
 
 ```ts
 beforeRequest(opts) {
@@ -752,21 +758,21 @@ beforeRequest(opts) {
 }
 ```
 
-Use **lowercase header names** in middleware. All keys are normalized to lowercase, so a different casing (`'Content-Type'` when `'content-type'` already exists) creates a duplicate entry rather than overriding it.
+Use **lowercase header names** in middleware. get-it normalizes all keys to lowercase. If you use a different case (`'Content-Type'` when `'content-type'` is present), you create a duplicate entry and you do not override the first entry.
 
 ## Entry points
 
-| Import              | Purpose                                                          |
-| ------------------- | ---------------------------------------------------------------- |
-| `get-it`            | Core. Includes environment proxy support in Node, Bun, and Deno. |
-| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`          |
-| `get-it/node`       | `createNodeFetch()` for custom undici dispatcher configuration   |
-| `get-it/mock`       | `createMockFetch()` and matchers, replacing `injectResponse()`   |
-| `get-it/vitest`     | Custom vitest matchers for mock assertions                       |
+| Import              | Purpose                                                             |
+| ------------------- | ------------------------------------------------------------------- |
+| `get-it`            | Core. It includes environment proxy support in Node, Bun, and Deno. |
+| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`             |
+| `get-it/node`       | `createNodeFetch()` for your own undici dispatcher configuration    |
+| `get-it/mock`       | `createMockFetch()` and matchers. It replaces `injectResponse()`    |
+| `get-it/vitest`     | Custom vitest matchers for mock assertions                          |
 
 ## TypeScript
 
-v9 is written in TypeScript with erasable type syntax. All types are exported:
+v9 is written in TypeScript with erasable type syntax. It exports all of the types:
 
 ```ts
 import type {

--- a/docs/mock.md
+++ b/docs/mock.md
@@ -1,8 +1,8 @@
 # Mock fetch and vitest matchers
 
-`get-it/mock` provides a mock fetch for testing code that uses get-it. There is no network access and no global patching: `createMockFetch()` returns an object whose `fetch` function you inject wherever you would normally pass `fetch`. It runs in any runtime get-it supports, with any test runner.
+`get-it/mock` gives you a mock fetch to test code that uses get-it. It uses no network and it patches no globals. `createMockFetch()` returns an object with a `fetch` function. You use this function where you normally pass `fetch`. The mock runs in any runtime that get-it supports, and with any test runner.
 
-`get-it/vitest` adds custom matchers to vitest's `expect` for asserting on the mock. See [Vitest matchers](#vitest-matchers).
+`get-it/vitest` adds custom matchers to the `expect` of vitest. Use them to assert on the mock. See [Vitest matchers](#vitest-matchers).
 
 - [Setup](#setup)
 - [Registering mocks](#registering-mocks)
@@ -22,7 +22,7 @@
 
 ## Setup
 
-Create a mock, inject `mock.fetch` into `createRequester`, register handlers, make requests:
+Create a mock. Inject `mock.fetch` into `createRequester`. Register the handlers. Then make the requests.
 
 ```ts
 import {createRequester} from 'get-it'
@@ -37,7 +37,7 @@ const res = await request({url: '/api/docs', as: 'json'})
 // res.body → {results: []}
 ```
 
-A typical test lifecycle asserts that every registered response was used, then resets:
+A typical test asserts that the code used every registered response. The test then resets the mock.
 
 ```ts
 afterEach(() => {
@@ -46,11 +46,11 @@ afterEach(() => {
 })
 ```
 
-`assertAllConsumed()` throws an `Error` listing each handler that still has unconsumed responses. Persistent responses (see [One-shot vs persistent mocks](#one-shot-vs-persistent-mocks)) never count as unconsumed.
+`assertAllConsumed()` throws an `Error`. The error lists each handler that still has unconsumed responses. Persistent responses (see [One-shot vs persistent mocks](#one-shot-vs-persistent-mocks)) never count as unconsumed.
 
 ## Registering mocks
 
-`mock.on(method, url, options?)` registers a handler and returns a builder for attaching responses:
+`mock.on(method, url, options?)` registers a handler. It returns a builder that attaches responses:
 
 - `method` - HTTP method, compared exactly (use uppercase: `'GET'`, `'POST'`, ...)
 - `url` - exact path, glob pattern, full URL, or predicate function (see [URL matching](#url-matching))
@@ -65,7 +65,7 @@ The builder methods all return the builder, so they chain:
 - `.respondWithError(error)` - reject the request once with a transport-level error
 - `.respondWithErrorPersist(error)` - reject every matching request
 
-Chained responses are consumed in order, which is useful for testing retries:
+The mock consumes chained responses in order. This behavior is useful when you test retries:
 
 ```ts
 mock
@@ -76,7 +76,7 @@ mock
 // First call → 500, second call → 200, third call → MockFetchError
 ```
 
-When several handlers could match a request, the first registered handler that matches and still has an available response wins. A handler whose responses are exhausted is skipped, so a later handler can take over.
+When several handlers can match a request, the mock uses the first handler that matches and still has an available response. The mock skips a handler with no more responses. A later handler can then match.
 
 ## Response definition
 
@@ -88,12 +88,12 @@ When several handlers could match a request, the first registered handler that m
 - `headers` - response headers as a plain record
 - `delay` - milliseconds before the response resolves (see below)
 
-The `body` value determines serialization:
+The `body` value sets how the mock serializes the body:
 
-- a string is returned as-is
+- the mock returns a string without a change
 - `undefined` or `null` produces an empty body
 - a `streamBody(...)` value streams chunks (see [Streaming response bodies](#streaming-response-bodies))
-- anything else is `JSON.stringify`-ed, and `content-type: application/json` is set unless you provided a `content-type` header yourself
+- for all other values, the mock uses `JSON.stringify`. It also sets `content-type: application/json`, unless you supply a `content-type` header
 
 ```ts
 mock.on('GET', '/api/docs').respond({
@@ -105,17 +105,17 @@ mock.on('GET', '/api/docs').respond({
 
 ### Delayed responses
 
-`delay` simulates server response time. The request is treated as sent immediately; the response resolves after `delay` milliseconds. Values of `0` or less resolve immediately.
+`delay` simulates the response time of the server. The mock sends the request immediately. The response resolves after `delay` milliseconds. A value of `0` or less resolves immediately.
 
 ```ts
 mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 100})
 ```
 
-If the request is aborted before the delay elapses (via an `AbortController` signal or a get-it `timeout`), the request rejects with the signal's reason and the pending timer is cleared. This makes timeout logic testable without a real server.
+If the request aborts before the delay is complete, the request rejects with the reason of the signal. An `AbortController` signal or a get-it `timeout` can cause this abort. The mock also clears the pending timer. With this behavior, you can test timeout logic without a real server.
 
 ## Simulating network errors
 
-`.respondWithError()` rejects the matched request the way a real `fetch()` rejects on a failed connection, instead of resolving to a response. The error is thrown unmodified, preserving `name`, `message`, and `cause`:
+`.respondWithError()` rejects the matched request and does not resolve to a response. A real `fetch()` rejects in the same way when a connection fails. The mock throws the error without a change, and it keeps `name`, `message`, and `cause`:
 
 ```ts
 mock
@@ -129,11 +129,11 @@ Pass a factory function to get a fresh error instance per rejection (useful with
 mock.onAny('/api/docs').respondWithErrorPersist(() => new TypeError('fetch failed'))
 ```
 
-Error responses behave like regular ones in every other respect:
+In all other conditions, error responses operate like regular responses:
 
-- Error responses chain with regular responses, so you can queue an error followed by a success to test retry recovery.
-- The request is still recorded (visible in `getRequests()`) even when it rejects.
-- One-shot error responses count toward consumption: `assertAllConsumed()` throws while an unconsumed `.respondWithError()` remains.
+- Error responses chain with regular responses. Thus you can queue an error, then a success, to test the recovery after a retry.
+- The mock records the request even when the request rejects. `getRequests()` shows it.
+- One-shot error responses are consumable. `assertAllConsumed()` throws when an unconsumed `.respondWithError()` remains.
 
 ## URL matching
 
@@ -142,7 +142,7 @@ The `url` argument to `on()` / `onAny()` accepts four forms:
 - an exact path: `/api/docs`
 - a glob pattern: `*` matches within one path segment, `**` matches across segments
 - a full URL with origin: `https://api.example.com/api/docs` (constrains the origin too)
-- a predicate function receiving the request path (without origin or query string) and returning a boolean
+- a predicate function that receives the request path (no origin, no query string) and returns a boolean
 
 ```ts
 mock.on('GET', '/api/docs/*/revisions').respond({status: 200, body: []})
@@ -153,11 +153,11 @@ mock.on('GET', (url) => url.startsWith('/api/')).respond({status: 200, body: 'ok
 
 Handlers registered with a plain path match requests to any host. Handlers registered with a full URL only match that origin.
 
-A URL pattern may include a query string (`/api/docs?limit=10`), which becomes a query constraint. Combining a query string in the URL pattern with an asymmetric `query` matcher in options throws at registration time; use one form or the other.
+A URL pattern can include a query string (`/api/docs?limit=10`). The query string becomes a query constraint. If you use a query string in the URL pattern and an asymmetric `query` matcher in the options, the registration throws. Use one form or the other.
 
 ## Query matching
 
-A handler with no query constraint matches any query parameters. Once you constrain the query (via a query string in the URL pattern or the `query` option), matching is strict: the request's query parameters must match the expected set exactly (same keys, same values).
+A handler with no query constraint matches any query parameters. You can constrain the query with a query string in the URL pattern, or with the `query` option. The match is then strict. The request must have the same keys and the same values as the expected set.
 
 ```ts
 mock.on('GET', '/api/docs', {query: {limit: '10'}}).respond({status: 200, body: {results: []}})
@@ -166,7 +166,7 @@ await request({url: '/api/docs', query: {limit: 10}}) // matches
 await request({url: '/api/docs', query: {limit: 10, offset: 0}}) // no match: extra key
 ```
 
-Number and boolean values in the `query` option are coerced to strings, since query parameters are always strings on the wire: `{limit: 10}` matches `?limit=10`.
+The mock converts number and boolean values in the `query` option to strings, because query parameters are always strings on the wire. Thus `{limit: 10}` matches `?limit=10`.
 
 For partial matching, use `queryContaining()` or any other [value matcher](#value-matchers):
 
@@ -180,7 +180,7 @@ mock
 
 ## Body matching
 
-A handler with no `body` option matches any request body. With a `body` option, matching is strict by default: objects must match deeply with the same keys, strings and bytes must be identical. Use [value matchers](#value-matchers) for partial matching.
+A handler with no `body` option matches any request body. With a `body` option, the match is strict by default. Objects must match deeply and have the same keys. Strings and bytes must be identical. For partial matching, use [value matchers](#value-matchers).
 
 ```ts
 import {objectContaining} from 'get-it/mock'
@@ -194,17 +194,17 @@ mock.on('POST', '/api/docs', {body: objectContaining({_type: 'post'})}).respond(
 
 ### How request bodies are normalized
 
-The mock normalizes each request body to a canonical form, used both for matching and for what `getRequests()` records:
+The mock normalizes each request body to a canonical form. It uses this form for the matching and for the records of `getRequests()`:
 
-- a string body with a JSON `content-type` is parsed, so you match against the object, not the JSON text (get-it serializes plain-object bodies this way, so they round-trip)
+- the mock parses a string body with a JSON `content-type`. You match against the object, not the JSON text. get-it serializes plain-object bodies in this way, so they round-trip
 - other string bodies stay strings
-- `Uint8Array` / `ArrayBuffer` / `Buffer` bodies are recorded as a `Uint8Array` snapshot (later mutation of the source does not affect the recording)
-- a `ReadableStream` body is drained and recorded as a single `Uint8Array`
-- a `Blob` or `File` body is recorded as its bytes (`Uint8Array`)
-- a `URLSearchParams` body becomes a plain record; a key appearing multiple times becomes an array of strings
-- a `FormData` body becomes a plain record; string fields stay strings, file fields become `{name, type, size, bytes}`, and repeated fields become arrays
+- the mock records `Uint8Array`, `ArrayBuffer`, and `Buffer` bodies as a `Uint8Array` snapshot (a later change to the source does not affect the record)
+- the mock drains a `ReadableStream` body and records it as one `Uint8Array`
+- the mock records a `Blob` or `File` body as its bytes (`Uint8Array`)
+- a `URLSearchParams` body becomes a plain record. A key that occurs more than one time becomes an array of strings
+- a `FormData` body becomes a plain record. String fields stay strings. File fields become `{name, type, size, bytes}`. Fields that occur more than one time become arrays
 
-The expected `body` you pass to `on()` may also be a native `URLSearchParams`, `FormData`, `Blob`, `Uint8Array`, or `ArrayBuffer`; it is normalized the same way before comparison. Binary bodies are compared byte-for-byte.
+The expected `body` that you pass to `on()` can also be a native `URLSearchParams`, `FormData`, `Blob`, `Uint8Array`, or `ArrayBuffer`. The mock normalizes it in the same way before the comparison. It compares binary bodies byte-for-byte.
 
 ```ts
 import {bodyBytes, objectContaining} from 'get-it/mock'
@@ -225,17 +225,17 @@ mock
 
 ### Synthesized content-type headers
 
-Mirroring platform `fetch`, the mock fills in the default `content-type` for body types that have one, when the request did not set one explicitly. The synthesized header is recorded and matchable:
+The mock supplies the default `content-type` for body types that have one, if the request does not set it. Platform `fetch` operates in the same way. The mock records this header, and you can match on it:
 
 - `URLSearchParams` → `application/x-www-form-urlencoded;charset=UTF-8`
-- `FormData` → `multipart/form-data; boundary=...` (the boundary is random; match the prefix with `stringMatching()`, not the whole value)
+- `FormData` → `multipart/form-data; boundary=...` (the boundary is random, so match the prefix with `stringMatching()`, not the whole value)
 - `Blob` / `File` → the blob's `type`, when set
 
-An explicit `content-type` header on the request always wins.
+An explicit `content-type` header on the request always has priority.
 
 ## Header matching
 
-The `headers` option uses containing semantics: only the headers you list are checked, extra request headers are ignored. Header names are compared case-insensitively. Values can be exact strings or [value matchers](#value-matchers), and the whole constraint can be a single asymmetric matcher:
+The `headers` option uses containing semantics. The mock compares only the headers that you list, and it ignores the other request headers. It compares header names without case sensitivity. Values can be exact strings or [value matchers](#value-matchers). The full constraint can also be one asymmetric matcher:
 
 ```ts
 import {objectContaining, stringMatching} from 'get-it/mock'
@@ -251,14 +251,14 @@ mock
 
 ## Value matchers
 
-`get-it/mock` exports asymmetric matchers for loose matching, usable anywhere an expected value goes (`query`, `body`, `headers`, nested values, and the vitest matchers):
+`get-it/mock` exports asymmetric matchers for loose matching. You can use them in each location that takes an expected value: `query`, `body`, `headers`, nested values, and the vitest matchers.
 
-- `objectContaining(subset)` - matches an object that contains at least the given keys with matching values; extra keys are ignored
+- `objectContaining(subset)` - matches an object that contains a minimum of the given keys, with matching values. It ignores extra keys
 - `arrayContaining(items)` - matches an array that contains at least the given items, in any order
-- `stringMatching(pattern)` - matches a string against a regex, or by substring when given a string
+- `stringMatching(pattern)` - matches a string against a regex. If you give it a string, it matches a substring
 - `anyValue()` - matches any value except `null`/`undefined` (same semantics as vitest's `expect.anything()`)
-- `queryContaining(subset)` - like `objectContaining` for query-shaped records: expected numbers/booleans are coerced to strings, and an array expected value matches a multi-value parameter containing each entry
-- `bodyBytes(bytes)` - matches a recorded binary body (`Uint8Array`) against exact bytes; accepts a `Uint8Array` or `ArrayBuffer`
+- `queryContaining(subset)` - like `objectContaining`, but for query-shaped records. It converts expected numbers and booleans to strings. An expected array matches a parameter that has each entry
+- `bodyBytes(bytes)` - matches a recorded binary body (`Uint8Array`) against exact bytes. It accepts a `Uint8Array` or an `ArrayBuffer`
 
 Matchers nest:
 
@@ -275,11 +275,11 @@ mock
   .respond({status: 201, body: {id: 'abc'}})
 ```
 
-They implement the `asymmetricMatch` protocol shared with vitest and Jest, so vitest's `expect.objectContaining()`, `expect.stringContaining()` and friends work in all the same places.
+The matchers use the `asymmetricMatch` protocol of vitest and Jest. Thus `expect.objectContaining()`, `expect.stringContaining()`, and the related vitest matchers work in the same locations.
 
 ## One-shot vs persistent mocks
 
-Responses queued with `.respond()` and `.respondWithError()` are one-shot: each is consumed by exactly one matching request, in registration order. When a handler's queue is exhausted, the handler no longer matches (later handlers get a chance, and if none match, a `MockFetchError` is thrown).
+Responses from `.respond()` and `.respondWithError()` are one-shot. Exactly one matching request consumes each response, in registration order. When the queue of a handler is empty, the handler no longer matches. The mock then tries the later handlers. If no handler matches, the mock throws a `MockFetchError`.
 
 `.respondPersist()` and `.respondWithErrorPersist()` register persistent responses that serve any number of requests:
 
@@ -288,13 +288,13 @@ mock.on('GET', '/api/config').respondPersist({status: 200, body: {feature: true}
 ```
 
 - A persistent response never counts as unconsumed for `assertAllConsumed()`.
-- Responses are picked in queue order, and a persistent response never exhausts, so anything queued after it on the same handler is unreachable.
+- The mock uses responses in queue order. A persistent response never becomes empty. Thus you cannot reach a response that you queue after it on the same handler.
 
-`mock.clear()` removes all handlers and recorded requests, resetting the instance.
+`mock.clear()` removes all handlers and all recorded requests. It resets the instance.
 
 ## Scoped mocks
 
-When code under test talks to multiple hosts, `mock.scope(baseUrl)` gives a view of the mock constrained to one origin:
+When the code under test uses more than one host, `mock.scope(baseUrl)` gives a view of the mock for one origin:
 
 ```ts
 const mock = createMockFetch()
@@ -316,21 +316,21 @@ A `MockScope` has `on()`, `onAny()`, `getRequests()`, and `assertAllConsumed()`:
 
 - Handlers registered through a scope only match requests to that origin.
 - `scope.getRequests()` only returns requests sent to that origin.
-- `scope.assertAllConsumed()` only checks handlers registered through that scope.
+- `scope.assertAllConsumed()` applies only to handlers that you register through that scope.
 - `scope()` requires a full URL with origin and throws on a relative path.
-- Registering a full URL through a scope uses the URL's own origin instead of the scope's.
+- If you register a full URL through a scope, the mock uses the origin of that URL, not the origin of the scope.
 
-Scopes and plain registration mix freely: handlers registered on the root mock with a plain path match any origin.
+You can mix scopes and plain registration. A handler on the root mock with a plain path matches any origin.
 
 ## Request recording
 
-Every request through `mock.fetch` is recorded, whether it matched or not (including requests that rejected via `respondWithError`). `mock.getRequests()` returns a fresh array of `RecordedRequest` objects in call order:
+The mock records every request through `mock.fetch`, and it also records the requests that do not match. It records the requests that rejected with `respondWithError`. `mock.getRequests()` returns a new array of `RecordedRequest` objects, in call order:
 
 - `method` - the HTTP method (`'GET'`, `'POST'`, ...)
 - `url` - the path portion, without origin or query string (`'/api/docs'`)
 - `fullUrl` - the complete URL as passed to fetch
 - `query` - query parameters parsed into a `Record<string, string>`
-- `headers` - a `Headers` instance, including any synthesized `content-type`
+- `headers` - a `Headers` instance, with any synthesized `content-type`
 - `body` - the normalized body (see [Body matching](#body-matching)), or `undefined`
 
 ```ts
@@ -346,7 +346,7 @@ req.headers.get('content-type') // 'application/json'
 
 ## Streaming response bodies
 
-`streamBody(...parts)` declares a response body delivered in chunks, with optional pauses, a permanent stall, or a mid-download error. Pass the result as `body` in a response definition:
+`streamBody(...parts)` declares a response body that the mock sends in chunks. The body can have pauses, a permanent stall, or an error during the download. Pass the result as `body` in a response definition:
 
 ```ts
 import {createMockFetch, streamBody, streamDelay, streamError, streamStall} from 'get-it/mock'
@@ -371,23 +371,23 @@ mock.on('GET', '/flaky').respond({
 
 Script parts:
 
-- a string chunk is UTF-8 encoded; a `Uint8Array` chunk passes through as bytes
-- `streamDelay(ms)` pauses before delivering the next part; allowed anywhere in the script
-- `streamStall()` never closes the body; the stream ends only when the consumer cancels it or the request's abort signal fires
+- the mock encodes a string chunk as UTF-8. It sends a `Uint8Array` chunk as bytes
+- `streamDelay(ms)` pauses before the next part. You can use it at any position in the script
+- `streamStall()` never closes the body. The stream ends only when the consumer cancels it, or when the abort signal of the request fires
 - `streamError(error)` errors the body stream with the given error
 
-`streamStall()` and `streamError()` are terminal: they must be the last part. The script is validated eagerly, so an invalid script throws a `TypeError` from `streamBody()` itself.
+`streamStall()` and `streamError()` are terminal: they must be the last part. The mock validates the script immediately, so an invalid script throws a `TypeError` from `streamBody()`.
 
-Streaming bodies compose with the rest of the response definition:
+Streaming bodies operate with the other parts of the response definition:
 
-- `delay` on the response definition still controls time-to-headers; the script controls the body after that.
-- A fresh stream is built from the script for every consumption, so a `streamBody` works with `respondPersist`.
-- Aborting the request signal errors the body with the abort reason, matching real fetch behavior.
-- Buffered reads (no `as` option, or `text()` / `arrayBuffer()`) drain the script with the same timing, so total-deadline timeout behavior is testable without `as: 'stream'`.
+- `delay` on the response definition still controls the time to the headers. The script controls the body after the headers.
+- The mock builds a new stream from the script for each use. Thus a `streamBody` works with `respondPersist`.
+- If the request signal aborts, the body errors with the abort reason. Real fetch operates in the same way.
+- Buffered reads (no `as` option, or `text()` and `arrayBuffer()`) drain the script with the same timing. Thus you can test the total deadline without `as: 'stream'`.
 
 ### The StreamBody handle
 
-The `streamBody()` return value doubles as an observability handle. Consumer cancellations of any stream built from the script are aggregated on it:
+The return value of `streamBody()` is also an observability handle. It counts the consumer cancellations of each stream from the script:
 
 - `cancelCount` - number of times a consumer cancelled a stream produced from this script
 - `lastCancelReason` - the reason passed to the most recent cancel, if any
@@ -402,7 +402,7 @@ expect(stalled.cancelCount).toBe(1)
 expect(stalled).toHaveBeenCancelled() // matcher from 'get-it/vitest'
 ```
 
-Cancellation (consumer calls `cancel()` on the stream) and abort (the request signal fires) are tracked separately: an abort errors the stream but does not increment `cancelCount`.
+The mock tracks cancellation and abort separately. A cancellation occurs when the consumer calls `cancel()` on the stream. An abort occurs when the request signal fires. An abort errors the stream, but it does not increment `cancelCount`.
 
 ## Unmatched requests and diagnostics
 
@@ -422,13 +422,13 @@ MockFetchError: No mock matched POST /api/documents?limit=10
     2. GET /api/other (1 responses remaining)
 ```
 
-The closest mock is chosen by scoring each handler on how many dimensions match (origin, method, URL, query, body, headers). Diffs are structural where possible: nested object bodies produce per-path entries like `body.attributes.title: expected "a", received "b"`, and binary bodies render as byte lengths (`Uint8Array(3 bytes)`).
+The mock scores each handler on the number of dimensions that match (origin, method, URL, query, body, headers). The handler with the best score is the closest mock. Diffs are structural when possible. A nested object body gives one entry for each path, such as `body.attributes.title: expected "a", received "b"`. A binary body shows a byte length (`Uint8Array(3 bytes)`).
 
-The error instance also exposes `method`, `url`, `query`, and `body` fields for programmatic inspection, and its `name` is `'MockFetchError'`. The class is exported from `get-it/mock` for `instanceof` checks.
+The error instance also has `method`, `url`, `query`, and `body` fields for inspection in code. Its `name` is `'MockFetchError'`. `get-it/mock` exports the class for `instanceof` tests.
 
 ## Vitest matchers
 
-`get-it/vitest` registers custom matchers on vitest's `expect` and augments vitest's types, both via a single side-effect import.
+`get-it/vitest` registers custom matchers on the `expect` of vitest. It also adds the vitest types. One side-effect import does both.
 
 ### Registration
 
@@ -439,7 +439,7 @@ Import it in a setup file:
 import 'get-it/vitest'
 ```
 
-And point vitest at the setup file:
+Then point vitest at the setup file:
 
 ```ts
 // vitest.config.ts
@@ -452,11 +452,11 @@ export default defineConfig({
 })
 ```
 
-The import calls `expect.extend()` with the matchers and includes a `declare module 'vitest'` augmentation, so TypeScript knows about the matchers as long as the setup file is part of your TypeScript project (for a single test file, importing `'get-it/vitest'` at the top works too). All matchers support negation with `.not`.
+The import calls `expect.extend()` with the matchers. It also includes a `declare module 'vitest'` augmentation. TypeScript then knows the matchers, if the setup file is part of your TypeScript project. For one test file, you can also import `'get-it/vitest'` at the top of that file. All matchers support negation with `.not`.
 
 ### Matchers on the mock instance
 
-`toHaveReceivedRequest(method, url, options?)` - asserts a matching request was recorded. The `url` accepts an exact path, a glob pattern, or a full URL (which also constrains the origin), and may include a query string. `options` accepts `query` and `body` constraints, including value matchers. The failure message lists all recorded requests.
+`toHaveReceivedRequest(method, url, options?)` - asserts that the mock recorded a matching request. The `url` accepts an exact path, a glob pattern, or a full URL (a full URL also constrains the origin). It can include a query string. `options` accepts `query` and `body` constraints, and it accepts value matchers. The failure message lists all recorded requests.
 
 ```ts
 expect(mock).toHaveReceivedRequest('POST', '/api/docs', {
@@ -465,14 +465,14 @@ expect(mock).toHaveReceivedRequest('POST', '/api/docs', {
 expect(mock).toHaveReceivedRequest('GET', '/api/docs?limit=10')
 ```
 
-`toHaveReceivedRequestTimes(method, url, times)` - asserts an exact number of matching requests. Same `url` forms; query strings in the `url` constrain the count.
+`toHaveReceivedRequestTimes(method, url, times)` - asserts an exact number of matching requests. It accepts the same `url` forms. A query string in the `url` constrains the count.
 
 ```ts
 expect(mock).toHaveReceivedRequestTimes('GET', '/api/docs', 2)
 expect(mock).toHaveReceivedRequestTimes('DELETE', '/api/docs/*', 0)
 ```
 
-`toHaveConsumedAllMocks()` - asserts every registered one-shot response was used; the assertion form of `mock.assertAllConsumed()`. On failure, the message lists the unconsumed handlers.
+`toHaveConsumedAllMocks()` - asserts that the code used every registered one-shot response. This matcher is the assertion form of `mock.assertAllConsumed()`. On a failure, the message lists the unconsumed handlers.
 
 ```ts
 expect(mock).toHaveConsumedAllMocks()
@@ -480,9 +480,9 @@ expect(mock).toHaveConsumedAllMocks()
 
 ### Matchers on recorded requests
 
-These operate on a single `RecordedRequest` from `mock.getRequests()`:
+These matchers operate on one `RecordedRequest` from `mock.getRequests()`:
 
-`toHaveHeader(name, value?)` - asserts a header matches. The name is case-insensitive (standard `Headers` semantics) and can be a string or an asymmetric matcher; the value can be a string or an asymmetric matcher. Omit the value to assert presence only, or combine with `.not` to assert absence.
+`toHaveHeader(name, value?)` - asserts that a header matches. The name is not case-sensitive (standard `Headers` semantics). The name can be a string or an asymmetric matcher. The value can also be a string or an asymmetric matcher. To assert presence only, omit the value. To assert absence, use `.not`.
 
 ```ts
 const [req] = mock.getRequests()
@@ -493,27 +493,27 @@ expect(req).not.toHaveHeader('x-legacy-auth') // absence
 expect(req).toHaveHeader(stringMatching(/^x-sanity-/), 'yes') // matcher for the name
 ```
 
-`toHaveBody(expected)` - asserts the normalized request body matches. Strict deep equality unless you use value matchers.
+`toHaveBody(expected)` - asserts that the normalized request body matches. The match is a strict deep equality, unless you use value matchers.
 
 ```ts
 expect(req).toHaveBody({title: 'Hello'})
 expect(req).toHaveBody(objectContaining({title: 'Hello'}))
 ```
 
-`toHaveQuery(expected)` - asserts the parsed query parameters match. Strict: all keys must be present and equal (values are strings). Use `queryContaining()` for partial matching.
+`toHaveQuery(expected)` - asserts that the parsed query parameters match. The match is strict: all keys must be present and equal (the values are strings). For partial matching, use `queryContaining()`.
 
 ```ts
 expect(req).toHaveQuery({limit: '10', offset: '0'})
 expect(req).toHaveQuery(queryContaining({limit: 10}))
 ```
 
-`toHaveMethod(expected)` - asserts the HTTP method.
+`toHaveMethod(expected)` - asserts that the HTTP method matches.
 
 ```ts
 expect(req).toHaveMethod('POST')
 ```
 
-`toHaveUrl(expected)` - asserts the request path (the `url` field: path only, no origin or query string) by exact string comparison.
+`toHaveUrl(expected)` - asserts the request path with an exact string comparison. The `url` field holds the path only, with no origin and no query string.
 
 ```ts
 expect(req).toHaveUrl('/api/docs')
@@ -521,7 +521,7 @@ expect(req).toHaveUrl('/api/docs')
 
 ### Matchers on stream bodies
 
-`toHaveBeenCancelled()` - asserts a `streamBody()` handle was cancelled by a consumer at least once. The failure message for `.not` includes the cancel count and last cancel reason.
+`toHaveBeenCancelled()` - asserts that a consumer cancelled a `streamBody()` handle one or more times. The failure message for `.not` gives the cancel count and the last cancel reason.
 
 ```ts
 const stalled = streamBody('partial', streamStall())

--- a/docs/mock.md
+++ b/docs/mock.md
@@ -1,6 +1,6 @@
 # Mock fetch and vitest matchers
 
-`get-it/mock` provides a mock fetch for testing code that uses get-it. There is no network access and no global patching: `createMockFetch()` returns an object whose `fetch` function you inject wherever you would normally pass `fetch`. It works in any runtime get-it works in, and with any test runner.
+`get-it/mock` provides a mock fetch for testing code that uses get-it. There is no network access and no global patching: `createMockFetch()` returns an object whose `fetch` function you inject wherever you would normally pass `fetch`. It runs in any runtime get-it supports, with any test runner.
 
 `get-it/vitest` adds custom matchers to vitest's `expect` for asserting on the mock. See [Vitest matchers](#vitest-matchers).
 
@@ -111,7 +111,7 @@ mock.on('GET', '/api/docs').respond({
 mock.on('GET', '/slow').respond({status: 200, body: {ok: true}, delay: 100})
 ```
 
-If the request is aborted before the delay elapses - via an `AbortController` signal or a get-it `timeout` - the request rejects with the signal's reason and the pending timer is cleared. This makes timeout logic testable without a real server.
+If the request is aborted before the delay elapses (via an `AbortController` signal or a get-it `timeout`), the request rejects with the signal's reason and the pending timer is cleared. This makes timeout logic testable without a real server.
 
 ## Simulating network errors
 
@@ -129,7 +129,7 @@ Pass a factory function to get a fresh error instance per rejection (useful with
 mock.onAny('/api/docs').respondWithErrorPersist(() => new TypeError('fetch failed'))
 ```
 
-Notes:
+Error responses behave like regular ones in every other respect:
 
 - Error responses chain with regular responses, so you can queue an error followed by a success to test retry recovery.
 - The request is still recorded (visible in `getRequests()`) even when it rejects.
@@ -157,7 +157,7 @@ A URL pattern may include a query string (`/api/docs?limit=10`), which becomes a
 
 ## Query matching
 
-A handler with no query constraint matches any query parameters. Once you constrain the query - via a query string in the URL pattern or the `query` option - matching is strict: the request's query parameters must match the expected set exactly (same keys, same values).
+A handler with no query constraint matches any query parameters. Once you constrain the query (via a query string in the URL pattern or the `query` option), matching is strict: the request's query parameters must match the expected set exactly (same keys, same values).
 
 ```ts
 mock.on('GET', '/api/docs', {query: {limit: '10'}}).respond({status: 200, body: {results: []}})
@@ -287,8 +287,6 @@ Responses queued with `.respond()` and `.respondWithError()` are one-shot: each 
 mock.on('GET', '/api/config').respondPersist({status: 200, body: {feature: true}})
 ```
 
-Details:
-
 - A persistent response never counts as unconsumed for `assertAllConsumed()`.
 - Responses are picked in queue order, and a persistent response never exhausts, so anything queued after it on the same handler is unreachable.
 
@@ -380,7 +378,7 @@ Script parts:
 
 `streamStall()` and `streamError()` are terminal: they must be the last part. The script is validated eagerly, so an invalid script throws a `TypeError` from `streamBody()` itself.
 
-Behavior:
+Streaming bodies compose with the rest of the response definition:
 
 - `delay` on the response definition still controls time-to-headers; the script controls the body after that.
 - A fresh stream is built from the script for every consumption, so a `streamBody` works with `respondPersist`.


### PR DESCRIPTION
Lots of cumbersome wordings in the docs have now been cleaned up, and contribution guide is tailored towards humans + agents, not just agents. A few corrections were also found and fixed along the way, and the changeset script is updated to match new build tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only plus changeset path logic for release automation; no runtime library code changes.
> 
> **Overview**
> This PR is **documentation and contributor workflow**, plus a small **CI changeset** alignment with current build tooling.
> 
> **Contributor docs:** Long TypeScript and testing rules move out of `AGENTS.md` into a new **`CONTRIBUTING.md`** (setup, bundle size, changesets, releases). `AGENTS.md` is shortened to point at that file and highlight the two main agent rules (no type assertions, no module mocks).
> 
> **User-facing docs:** `README.md` gets clearer wording, **npmx.dev** badges instead of npm/bundlephobia shields, explicit **`timeout` default `120_000`**, and a **Contributing** link; maintainer release steps are dropped from the README in favor of `CONTRIBUTING.md`. **`docs/mock.md`** and **`docs/MIGRATION-v9.md`** are edited for readability (shorter sentences, clearer structure); the migration guide’s agent playbook and entry-point tables are tightened, including **`get-it/mock`** as the testing replacement for `injectResponse()`.
> 
> **Release bot:** `generate-changeset.mjs` treats **`tsdown.config.ts`** and **`tsconfig.dist.json`** as publish-affecting paths (replacing `package.config.ts`), with comments explaining why build config changes can warrant a release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d817e516a82a5238a829cb692009ecc1da14879f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->