### PR TITLE
feat: preserve response metadata and add error guards

### DIFF
--- a/.changeset/pr-652.md
+++ b/.changeset/pr-652.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': minor
+---
+
+feat: preserve response metadata and add error guards

--- a/README.md
+++ b/README.md
@@ -172,9 +172,10 @@ const res = await request({url: '/maybe-404', httpErrors: false})
 release, where `instanceof HttpError` would fail for another installed copy.
 It narrows to `HttpErrorLike`; newer response fields such as `response.url` are
 optional because early v9 releases did not include them. `isTimeoutError()`
-does the same for get-it's headers-phase `TimeoutError`. Total-deadline timeouts
-are platform `DOMException`s; check their `name === 'TimeoutError'` when you
-need to handle both timeout categories.
+recognizes both get-it's headers-phase `TimeoutError` and the platform
+`DOMException` used for total-deadline timeouts. Check for
+`error.code === 'ETIMEDOUT'` after narrowing when you need to distinguish the
+headers timeout.
 
 ## Cancellation
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ optional because early v9 releases did not include them. `isTimeoutError()`
 recognizes both get-it's headers-phase `TimeoutError` and the platform
 `DOMException` used for total-deadline timeouts. Check for
 `error.code === 'ETIMEDOUT'` after narrowing when you need to distinguish the
-headers timeout.
+headers timeout. The guard also accepts DOM implementations such as happy-dom
+that omit the spec-required numeric `code`.
 
 ## Cancellation
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ const res = await request('/data')
 res.status // number
 res.statusText // string
 res.headers // Headers
+res.url // final response URL after redirects
+res.redirected // whether the response resulted from following a redirect
 res.body // Uint8Array
 res.json() // parse as JSON (synchronous)
 res.text() // decode as string (synchronous)
@@ -151,12 +153,12 @@ const res = await request({url: 'https://example.com/big-file', as: 'stream'})
 ## Error handling
 
 ```ts
-import {HttpError} from 'get-it'
+import {isHttpError} from 'get-it'
 
 try {
   await request('/not-found')
 } catch (err) {
-  if (err instanceof HttpError) {
+  if (isHttpError(err)) {
     console.log(err.status) // 404
     console.log(err.response) // full response object
   }
@@ -165,6 +167,14 @@ try {
 // Disable for a single request
 const res = await request({url: '/maybe-404', httpErrors: false})
 ```
+
+`isHttpError()` recognizes the stable HTTP error shape from any get-it v9
+release, where `instanceof HttpError` would fail for another installed copy.
+It narrows to `HttpErrorLike`; newer response fields such as `response.url` are
+optional because early v9 releases did not include them. `isTimeoutError()`
+does the same for get-it's headers-phase `TimeoutError`. Total-deadline timeouts
+are platform `DOMException`s; check their `name === 'TimeoutError'` when you
+need to handle both timeout categories.
 
 ## Cancellation
 

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -472,7 +472,8 @@ metadata is optional because early v9 releases did not include it.
 `isTimeoutError()` recognizes both get-it's headers-phase `TimeoutError` and
 the platform `DOMException` used for total-deadline timeouts. Check for
 `error.code === 'ETIMEDOUT'` after narrowing when you need to distinguish the
-headers timeout.
+headers timeout. The guard also accepts DOM implementations such as happy-dom
+that omit the spec-required numeric `code`.
 
 ## Timeout
 

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -359,11 +359,17 @@ response.body // pre-parsed body (depends on middleware)
 response.status // number
 response.statusText // string
 response.headers // Headers instance (use .get(), .has(), .forEach())
+response.url // final response URL after redirects
+response.redirected // whether the response resulted from following a redirect
 response.body // Uint8Array (default), or typed based on `as` option
 response.json() // parse body as JSON (synchronous, returns unknown)
 response.text() // decode body as UTF-8 string (synchronous)
 response.bytes() // returns body as Uint8Array (synchronous)
 ```
+
+All v9 response modes expose `url` and `redirected`. `url` is the final URL
+reported by fetch after redirect handling. On an `HttpError`, `error.url` is
+the attempted request URL and `error.response.url` is the final response URL.
 
 ### Reading response headers
 
@@ -443,20 +449,29 @@ const request = createRequester({httpErrors: false})
 const res = await request({url: '/maybe-404', httpErrors: false})
 ```
 
-The `HttpError` class is exported from `get-it`:
+The `HttpError` class and a cross-package structural guard are exported from
+`get-it`:
 
 ```ts
-import {HttpError} from 'get-it'
+import {isHttpError} from 'get-it'
 
 try {
   await request('/not-found')
 } catch (err) {
-  if (err instanceof HttpError) {
+  if (isHttpError(err)) {
     console.log(err.status) // 404
     console.log(err.response) // full response object
   }
 }
 ```
+
+Use `isHttpError()` instead of `instanceof HttpError` when an application can
+contain more than one installed get-it version. It recognizes the stable error
+shape shared by all v9 releases and narrows to `HttpErrorLike`; response URL
+metadata is optional because early v9 releases did not include it.
+`isTimeoutError()` provides the same structural check for get-it's
+headers-phase `TimeoutError` class. It does not match the platform
+`DOMException` used for total-deadline timeouts.
 
 ## Timeout
 
@@ -778,6 +793,7 @@ v9 is written in TypeScript with erasable type syntax. It exports all of the typ
 import type {
   RequestOptions,
   BufferedResponse,
+  HttpErrorLike,
   JsonResponse,
   TextResponse,
   StreamResponse,

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -469,9 +469,10 @@ Use `isHttpError()` instead of `instanceof HttpError` when an application can
 contain more than one installed get-it version. It recognizes the stable error
 shape shared by all v9 releases and narrows to `HttpErrorLike`; response URL
 metadata is optional because early v9 releases did not include it.
-`isTimeoutError()` provides the same structural check for get-it's
-headers-phase `TimeoutError` class. It does not match the platform
-`DOMException` used for total-deadline timeouts.
+`isTimeoutError()` recognizes both get-it's headers-phase `TimeoutError` and
+the platform `DOMException` used for total-deadline timeouts. Check for
+`error.code === 'ETIMEDOUT'` after narrowing when you need to distinguish the
+headers timeout.
 
 ## Timeout
 

--- a/src/_exports/index.node.ts
+++ b/src/_exports/index.node.ts
@@ -43,6 +43,8 @@ export function createRequester(
 
 // Re-export everything from core
 export {HttpError, TimeoutError} from '../errors'
+export {isHttpError, isTimeoutError} from '../errorGuards'
+export type {HttpErrorLike} from '../errorGuards'
 export type {
   BufferedResponse,
   DefaultResponse,

--- a/src/_exports/index.node.ts
+++ b/src/_exports/index.node.ts
@@ -44,7 +44,7 @@ export function createRequester(
 // Re-export everything from core
 export {HttpError, TimeoutError} from '../errors'
 export {isHttpError, isTimeoutError} from '../errorGuards'
-export type {HttpErrorLike} from '../errorGuards'
+export type {HttpErrorLike, TimeoutErrorLike} from '../errorGuards'
 export type {
   BufferedResponse,
   DefaultResponse,

--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -1,7 +1,7 @@
 export {createRequester} from '../createRequester'
 export {HttpError, TimeoutError} from '../errors'
 export {isHttpError, isTimeoutError} from '../errorGuards'
-export type {HttpErrorLike} from '../errorGuards'
+export type {HttpErrorLike, TimeoutErrorLike} from '../errorGuards'
 export type {
   BufferedResponse,
   DefaultResponse,

--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -1,5 +1,7 @@
 export {createRequester} from '../createRequester'
 export {HttpError, TimeoutError} from '../errors'
+export {isHttpError, isTimeoutError} from '../errorGuards'
+export type {HttpErrorLike} from '../errorGuards'
 export type {
   BufferedResponse,
   DefaultResponse,

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -272,6 +272,8 @@ export function createRequester(
         response.statusText,
         response.headers,
         new Uint8Array(0),
+        response.url,
+        response.redirected,
       )
     }
 
@@ -590,12 +592,7 @@ function buildFetchArgs(
  * Optionally throws HttpError for error status codes.
  */
 async function bufferAndCheck(
-  response: {
-    status: number
-    statusText: string
-    headers: Headers
-    arrayBuffer(): Promise<ArrayBuffer>
-  },
+  response: FetchResponse,
   httpErrors: boolean,
   requestUrl: string,
   requestMethod: string,
@@ -607,6 +604,8 @@ async function bufferAndCheck(
     response.statusText,
     response.headers,
     bytes,
+    response.url,
+    response.redirected,
   )
 
   if (httpErrors && response.status >= 400) {
@@ -682,10 +681,30 @@ function runAfterResponse(
 }
 
 function responseOf<T>(
-  source: {status: number; statusText: string; headers: Headers},
+  source: {
+    status: number
+    statusText: string
+    headers: Headers
+    url: string
+    redirected: boolean
+  },
   body: T,
-): {status: number; statusText: string; headers: Headers; body: T} {
-  return {status: source.status, statusText: source.statusText, headers: source.headers, body}
+): {
+  status: number
+  statusText: string
+  headers: Headers
+  url: string
+  redirected: boolean
+  body: T
+} {
+  return {
+    status: source.status,
+    statusText: source.statusText,
+    headers: source.headers,
+    url: source.url,
+    redirected: source.redirected,
+    body,
+  }
 }
 
 /**

--- a/src/errorGuards.ts
+++ b/src/errorGuards.ts
@@ -28,6 +28,20 @@ export interface HttpErrorLike {
 }
 
 /**
+ * A timeout raised by get-it or the platform, described structurally so the
+ * type works across runtimes, realms, and installed get-it copies.
+ *
+ * @public
+ */
+export type TimeoutErrorLike =
+  | TimeoutError
+  | {
+      name: 'TimeoutError'
+      message: string
+      code: number
+    }
+
+/**
  * Checks whether a value has the public shape of a get-it {@link HttpError}.
  *
  * Unlike `instanceof HttpError`, this recognizes errors created by another
@@ -66,28 +80,30 @@ export function isHttpError(error: unknown): error is HttpErrorLike {
 }
 
 /**
- * Checks whether a value has the public shape of get-it's headers-phase
- * {@link TimeoutError}.
+ * Checks whether a value is a get-it headers timeout or a platform
+ * total-deadline timeout.
  *
- * Unlike `instanceof TimeoutError`, this recognizes errors created by another
- * installed copy of get-it. Total-deadline timeouts are platform
- * `DOMException`s and are not matched by this guard.
+ * This structural check recognizes errors created by another installed copy
+ * of get-it and platform `DOMException`s from another realm.
  *
  * @param error - The value to check.
- * @returns `true` when the value is a get-it headers-phase timeout error.
+ * @returns `true` when the value is a timeout error.
  *
  * @public
  */
-export function isTimeoutError(error: unknown): error is TimeoutError {
+export function isTimeoutError(error: unknown): error is TimeoutErrorLike {
+  if (!isRecord(error) || error.name !== 'TimeoutError' || typeof error.message !== 'string') {
+    return false
+  }
+
+  if (typeof error.code === 'number') return true
+
   return (
-    isRecord(error) &&
-    error.name === 'TimeoutError' &&
-    typeof error.message === 'string' &&
+    error.code === 'ETIMEDOUT' &&
     typeof error.url === 'string' &&
     typeof error.method === 'string' &&
     typeof error.timeoutMs === 'number' &&
-    error.phase === 'headers' &&
-    error.code === 'ETIMEDOUT'
+    error.phase === 'headers'
   )
 }
 

--- a/src/errorGuards.ts
+++ b/src/errorGuards.ts
@@ -1,0 +1,117 @@
+import type {TimeoutError} from './errors'
+
+/**
+ * The public HTTP error fields shared by all get-it v9 releases.
+ *
+ * Response URL metadata was added after v9.4, so it is optional on this
+ * cross-version shape.
+ *
+ * @public
+ */
+export interface HttpErrorLike {
+  name: 'HttpError'
+  message: string
+  url: string
+  method: string
+  status: number
+  statusText: string
+  headers: Headers
+  body: unknown
+  response: {
+    status: number
+    statusText: string
+    headers: Headers
+    body: unknown
+    url?: string
+    redirected?: boolean
+  }
+}
+
+/**
+ * Checks whether a value has the public shape of a get-it {@link HttpError}.
+ *
+ * Unlike `instanceof HttpError`, this recognizes errors created by another
+ * installed copy of get-it.
+ *
+ * @param error - The value to check.
+ * @returns `true` when the value is a get-it HTTP error.
+ *
+ * @public
+ */
+export function isHttpError(error: unknown): error is HttpErrorLike {
+  if (
+    !isRecord(error) ||
+    error.name !== 'HttpError' ||
+    typeof error.message !== 'string' ||
+    typeof error.url !== 'string' ||
+    typeof error.method !== 'string' ||
+    typeof error.status !== 'number' ||
+    typeof error.statusText !== 'string' ||
+    !isHeaders(error.headers) ||
+    !('body' in error) ||
+    !isRecord(error.response)
+  ) {
+    return false
+  }
+
+  const response = error.response
+  return (
+    response.status === error.status &&
+    typeof response.statusText === 'string' &&
+    isHeaders(response.headers) &&
+    'body' in response &&
+    (response.url === undefined || typeof response.url === 'string') &&
+    (response.redirected === undefined || typeof response.redirected === 'boolean')
+  )
+}
+
+/**
+ * Checks whether a value has the public shape of get-it's headers-phase
+ * {@link TimeoutError}.
+ *
+ * Unlike `instanceof TimeoutError`, this recognizes errors created by another
+ * installed copy of get-it. Total-deadline timeouts are platform
+ * `DOMException`s and are not matched by this guard.
+ *
+ * @param error - The value to check.
+ * @returns `true` when the value is a get-it headers-phase timeout error.
+ *
+ * @public
+ */
+export function isTimeoutError(error: unknown): error is TimeoutError {
+  return (
+    isRecord(error) &&
+    error.name === 'TimeoutError' &&
+    typeof error.message === 'string' &&
+    typeof error.url === 'string' &&
+    typeof error.method === 'string' &&
+    typeof error.timeoutMs === 'number' &&
+    error.phase === 'headers' &&
+    error.code === 'ETIMEDOUT'
+  )
+}
+
+interface ErrorRecord {
+  name?: unknown
+  message?: unknown
+  url?: unknown
+  method?: unknown
+  status?: unknown
+  statusText?: unknown
+  headers?: unknown
+  body?: unknown
+  response?: unknown
+  redirected?: unknown
+  timeoutMs?: unknown
+  phase?: unknown
+  code?: unknown
+  get?: unknown
+}
+
+function isRecord(value: unknown): value is ErrorRecord {
+  return typeof value === 'object' && value !== null
+}
+
+function isHeaders(value: unknown): value is Headers {
+  return isRecord(value) && typeof value.get === 'function'
+}

--- a/src/errorGuards.ts
+++ b/src/errorGuards.ts
@@ -38,7 +38,7 @@ export type TimeoutErrorLike =
   | {
       name: 'TimeoutError'
       message: string
-      code: number
+      code?: number
     }
 
 /**
@@ -96,7 +96,7 @@ export function isTimeoutError(error: unknown): error is TimeoutErrorLike {
     return false
   }
 
-  if (typeof error.code === 'number') return true
+  if (error.code === undefined || typeof error.code === 'number') return true
 
   return (
     error.code === 'ETIMEDOUT' &&

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,6 +7,8 @@ import type {BufferedResponse, JsonResponse, TextResponse} from './types'
  * @public
  */
 export class HttpError extends Error {
+  /** Stable error discriminator. */
+  declare name: 'HttpError'
   /** The URL that was requested. */
   declare url: string
   /** The HTTP method used (e.g. `"GET"`, `"POST"`). */
@@ -58,6 +60,8 @@ export class HttpError extends Error {
  * @public
  */
 export class TimeoutError extends Error {
+  /** Stable error discriminator. */
+  declare name: 'TimeoutError'
   /** The URL that was requested. */
   declare url: string
   /** The HTTP method used (e.g. `"GET"`, `"POST"`). */

--- a/src/response.ts
+++ b/src/response.ts
@@ -10,6 +10,8 @@ let decoder: InstanceType<typeof TextDecoder>
  * @param statusText - HTTP status text.
  * @param headers - Response headers.
  * @param body - Raw response body bytes.
+ * @param url - Final response URL after redirects.
+ * @param redirected - Whether the response resulted from following a redirect.
  * @returns A buffered response with `text()`, `json()`, and `bytes()` accessors.
  *
  * @internal
@@ -19,6 +21,8 @@ export function createBufferedResponse(
   statusText: string,
   headers: Headers,
   body: Uint8Array,
+  url: string,
+  redirected: boolean,
 ): BufferedResponse {
   let cachedText: string | undefined
   let cachedJson: {value: unknown} | undefined
@@ -27,6 +31,8 @@ export function createBufferedResponse(
     status,
     statusText,
     headers,
+    url,
+    redirected,
     body,
 
     text(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,10 @@ export interface BufferedResponse {
   statusText: string
   /** Response headers. */
   headers: Headers
+  /** The final response URL after redirects. */
+  url: string
+  /** Whether the response resulted from following a redirect. */
+  redirected: boolean
   /** Raw response body bytes. */
   body: Uint8Array
   /** Parses the body as JSON. The result is cached after the first call. */
@@ -289,6 +293,10 @@ export interface JsonResponse<T = unknown> {
   statusText: string
   /** Response headers. */
   headers: Headers
+  /** The final response URL after redirects. */
+  url: string
+  /** Whether the response resulted from following a redirect. */
+  redirected: boolean
   /** Parsed JSON body. */
   body: T
 }
@@ -307,6 +315,10 @@ export interface TextResponse {
   statusText: string
   /** Response headers. */
   headers: Headers
+  /** The final response URL after redirects. */
+  url: string
+  /** Whether the response resulted from following a redirect. */
+  redirected: boolean
   /** Response body decoded as a string. */
   body: string
 }
@@ -325,6 +337,10 @@ export interface StreamResponse {
   statusText: string
   /** Response headers. */
   headers: Headers
+  /** The final response URL after redirects. */
+  url: string
+  /** Whether the response resulted from following a redirect. */
+  redirected: boolean
   /** Readable stream of the response body. */
   body: ReadableStream<Uint8Array>
 }

--- a/test/errorGuards.test.ts
+++ b/test/errorGuards.test.ts
@@ -130,14 +130,33 @@ describe('isTimeoutError', () => {
     })
 
     if (!isTimeoutError(error)) throw new Error('expected a timeout error')
+    if (error.code !== 'ETIMEDOUT') throw new Error('expected a headers timeout')
     expect(error.phase).toBe('headers')
     expect(error.code).toBe('ETIMEDOUT')
   })
 
-  it('does not classify a total-deadline DOMException as the get-it class', () => {
+  it('recognizes a total-deadline DOMException', () => {
     const error = new DOMException('The operation timed out', 'TimeoutError')
 
-    expect(isTimeoutError(error)).toBe(false)
+    expect(isTimeoutError(error)).toBe(true)
+  })
+
+  it('recognizes the platform shape from another realm', () => {
+    const crossRealmError = {
+      name: 'TimeoutError',
+      message: 'The operation timed out',
+      code: 23,
+    }
+
+    expect(crossRealmError).not.toBeInstanceOf(DOMException)
+    expect(isTimeoutError(crossRealmError)).toBe(true)
+  })
+
+  it('narrows platform timeout errors', () => {
+    const error: unknown = new DOMException('The operation timed out', 'TimeoutError')
+
+    if (!isTimeoutError(error)) throw new Error('expected a timeout error')
+    expect(error.code).toBe(23)
   })
 
   it('rejects malformed and non-object values', () => {

--- a/test/errorGuards.test.ts
+++ b/test/errorGuards.test.ts
@@ -156,11 +156,15 @@ describe('isTimeoutError', () => {
     const error: unknown = new DOMException('The operation timed out', 'TimeoutError')
 
     if (!isTimeoutError(error)) throw new Error('expected a timeout error')
-    expect(error.code).toBe(23)
+    expect(error.name).toBe('TimeoutError')
+    expect(error.message).toBe('The operation timed out')
   })
 
   it('rejects malformed and non-object values', () => {
     expect(isTimeoutError({name: 'TimeoutError'})).toBe(false)
+    expect(
+      isTimeoutError({name: 'TimeoutError', message: 'not a supported timeout', code: 'OTHER'}),
+    ).toBe(false)
     expect(isTimeoutError(undefined)).toBe(false)
   })
 })

--- a/test/errorGuards.test.ts
+++ b/test/errorGuards.test.ts
@@ -1,0 +1,147 @@
+import type {HttpErrorLike} from 'get-it'
+import {HttpError, isHttpError, isTimeoutError, TimeoutError} from 'get-it'
+import {describe, expect, it} from 'vitest'
+
+import {createBufferedResponse} from '../src/response'
+
+const requestUrl = 'https://example.com/original'
+const responseUrl = 'https://example.com/final'
+
+function createHttpError(): HttpError {
+  const response = createBufferedResponse(
+    404,
+    'Not Found',
+    new Headers(),
+    new Uint8Array(),
+    responseUrl,
+    true,
+  )
+  return new HttpError({
+    url: requestUrl,
+    method: 'GET',
+    status: 404,
+    statusText: 'Not Found',
+    headers: response.headers,
+    body: response.body,
+    response,
+  })
+}
+
+describe('isHttpError', () => {
+  it('recognizes an HttpError from this get-it copy', () => {
+    const error: HttpErrorLike = createHttpError()
+    expect(isHttpError(error)).toBe(true)
+  })
+
+  it('recognizes the public shape from another get-it copy', () => {
+    const error = createHttpError()
+    const crossVersionError = {
+      name: error.name,
+      message: error.message,
+      url: error.url,
+      method: error.method,
+      status: error.status,
+      statusText: error.statusText,
+      headers: error.headers,
+      body: error.body,
+      response: {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        headers: error.response.headers,
+        body: error.response.body,
+      },
+    }
+
+    expect(crossVersionError).not.toBeInstanceOf(HttpError)
+    expect(isHttpError(crossVersionError)).toBe(true)
+  })
+
+  it('narrows the error type', () => {
+    const error: unknown = createHttpError()
+
+    if (!isHttpError(error)) throw new Error('expected an HTTP error')
+    expect(error.status).toBe(404)
+    expect(error.response.url).toBe(responseUrl)
+  })
+
+  it('rejects errors with only the same name', () => {
+    const error = new Error('not an HTTP error')
+    error.name = 'HttpError'
+
+    expect(isHttpError(error)).toBe(false)
+  })
+
+  it('rejects malformed response details', () => {
+    const error = createHttpError()
+    const malformed = {
+      name: error.name,
+      message: error.message,
+      url: error.url,
+      method: error.method,
+      status: error.status,
+      statusText: error.statusText,
+      headers: error.headers,
+      body: error.body,
+      response: {status: '404'},
+    }
+
+    expect(isHttpError(malformed)).toBe(false)
+  })
+
+  it('rejects non-objects', () => {
+    expect(isHttpError(null)).toBe(false)
+    expect(isHttpError('HttpError')).toBe(false)
+  })
+})
+
+describe('isTimeoutError', () => {
+  it('recognizes a TimeoutError from this get-it copy', () => {
+    const error = new TimeoutError({
+      url: requestUrl,
+      method: 'GET',
+      timeoutMs: 1000,
+      phase: 'headers',
+    })
+
+    expect(isTimeoutError(error)).toBe(true)
+  })
+
+  it('recognizes the public shape from another get-it copy', () => {
+    const crossVersionError = {
+      name: 'TimeoutError',
+      message: 'Request timed out waiting for response headers',
+      url: requestUrl,
+      method: 'GET',
+      timeoutMs: 1000,
+      phase: 'headers',
+      code: 'ETIMEDOUT',
+    }
+
+    expect(crossVersionError).not.toBeInstanceOf(TimeoutError)
+    expect(isTimeoutError(crossVersionError)).toBe(true)
+  })
+
+  it('narrows the error type', () => {
+    const error: unknown = new TimeoutError({
+      url: requestUrl,
+      method: 'GET',
+      timeoutMs: 1000,
+      phase: 'headers',
+    })
+
+    if (!isTimeoutError(error)) throw new Error('expected a timeout error')
+    expect(error.phase).toBe('headers')
+    expect(error.code).toBe('ETIMEDOUT')
+  })
+
+  it('does not classify a total-deadline DOMException as the get-it class', () => {
+    const error = new DOMException('The operation timed out', 'TimeoutError')
+
+    expect(isTimeoutError(error)).toBe(false)
+  })
+
+  it('rejects malformed and non-object values', () => {
+    expect(isTimeoutError({name: 'TimeoutError'})).toBe(false)
+    expect(isTimeoutError(undefined)).toBe(false)
+  })
+})

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -348,7 +348,14 @@ describe('middleware system', () => {
 
   it('stream mode throws when wrapping middleware never calls next', async () => {
     const shortCircuit = async () => {
-      return createBufferedResponse(200, 'OK', new Headers(), new Uint8Array())
+      return createBufferedResponse(
+        200,
+        'OK',
+        new Headers(),
+        new Uint8Array(),
+        'https://example.com',
+        false,
+      )
     }
     const request = createRequester({base: baseUrl, middleware: [shortCircuit]})
     await expect(request({url: '/plain-text', as: 'stream'})).rejects.toThrow(

--- a/test/proxy.node.test.ts
+++ b/test/proxy.node.test.ts
@@ -108,6 +108,8 @@ describe('node entry point', () => {
     const mod = await import('../src/_exports/index.node')
     expect(typeof mod.createRequester).toBe('function')
     expect(typeof mod.HttpError).toBe('function')
+    expect(typeof mod.isHttpError).toBe('function')
+    expect(typeof mod.isTimeoutError).toBe('function')
   })
 
   it('createRequester from node entry works without custom fetch', async () => {

--- a/test/response-metadata.test.ts
+++ b/test/response-metadata.test.ts
@@ -1,0 +1,88 @@
+import type {FetchFunction} from 'get-it'
+import {createRequester, HttpError} from 'get-it'
+import {describe, expect, it} from 'vitest'
+
+const finalUrl = 'https://example.com/final'
+
+const redirectedFetch: FetchFunction = async () => {
+  const bytes = new TextEncoder().encode('{"ok":true}')
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({'content-type': 'application/json'}),
+    url: finalUrl,
+    redirected: true,
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes)
+        controller.close()
+      },
+    }),
+    text: () => Promise.resolve('{"ok":true}'),
+    arrayBuffer: () => Promise.resolve(bytes.buffer),
+  }
+}
+
+describe('response metadata', () => {
+  const request = createRequester({fetch: redirectedFetch})
+
+  it('preserves metadata on buffered responses', async () => {
+    const response = await request('https://example.com/original')
+
+    expect(response.url).toBe(finalUrl)
+    expect(response.redirected).toBe(true)
+  })
+
+  it('preserves metadata on JSON responses', async () => {
+    const response = await request({url: 'https://example.com/original', as: 'json'})
+
+    expect(response.url).toBe(finalUrl)
+    expect(response.redirected).toBe(true)
+  })
+
+  it('preserves metadata on text responses', async () => {
+    const response = await request({url: 'https://example.com/original', as: 'text'})
+
+    expect(response.url).toBe(finalUrl)
+    expect(response.redirected).toBe(true)
+  })
+
+  it('preserves metadata on stream responses', async () => {
+    const response = await request({url: 'https://example.com/original', as: 'stream'})
+
+    expect(response.url).toBe(finalUrl)
+    expect(response.redirected).toBe(true)
+    await response.body.cancel()
+  })
+
+  it('keeps the requested URL on HttpError and final URL on its response', async () => {
+    const failedFetch: FetchFunction = async () => {
+      const bytes = new TextEncoder().encode('failed')
+      return {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+        url: finalUrl,
+        redirected: true,
+        body: null,
+        text: () => Promise.resolve('failed'),
+        arrayBuffer: () => Promise.resolve(bytes.buffer),
+      }
+    }
+    const failedRequest = createRequester({fetch: failedFetch})
+
+    try {
+      await failedRequest('https://example.com/original')
+      expect.fail('request should have failed')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(HttpError)
+      if (error instanceof HttpError) {
+        expect(error.url).toBe('https://example.com/original')
+        expect(error.response.url).toBe(finalUrl)
+        expect(error.response.redirected).toBe(true)
+      }
+    }
+  })
+})

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -2,41 +2,52 @@ import {describe, expect, it} from 'vitest'
 
 import {createBufferedResponse} from '../src/response'
 
+const finalUrl = 'https://example.com/final'
+
 describe('createBufferedResponse', () => {
   it('exposes status, statusText, headers', () => {
-    const res = createBufferedResponse(200, 'OK', new Headers({'x-test': '1'}), new Uint8Array())
+    const res = createBufferedResponse(
+      200,
+      'OK',
+      new Headers({'x-test': '1'}),
+      new Uint8Array(),
+      finalUrl,
+      true,
+    )
     expect(res.status).toBe(200)
     expect(res.statusText).toBe('OK')
     expect(res.headers.get('x-test')).toBe('1')
+    expect(res.url).toBe(finalUrl)
+    expect(res.redirected).toBe(true)
   })
 
   it('body is the raw Uint8Array', () => {
     const bytes = new TextEncoder().encode('hello')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(res.body).toEqual(bytes)
   })
 
   it('.text() decodes body as UTF-8 string', () => {
     const bytes = new TextEncoder().encode('hello world')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(res.text()).toBe('hello world')
   })
 
   it('.json() parses body as JSON', () => {
     const bytes = new TextEncoder().encode('{"name":"espen"}')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(res.json()).toEqual({name: 'espen'})
   })
 
   it('.bytes() returns the same Uint8Array', () => {
     const bytes = new TextEncoder().encode('data')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(res.bytes()).toBe(bytes)
   })
 
   it('.json() and .text() can be called multiple times', () => {
     const bytes = new TextEncoder().encode('"hello"')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(res.json()).toBe('hello')
     expect(res.json()).toBe('hello')
     expect(res.text()).toBe('"hello"')
@@ -44,26 +55,33 @@ describe('createBufferedResponse', () => {
 
   it('.json() throws on invalid JSON', () => {
     const bytes = new TextEncoder().encode('not json')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(() => res.json()).toThrow()
   })
 
   it('handles empty body', () => {
-    const res = createBufferedResponse(204, 'No Content', new Headers(), new Uint8Array())
+    const res = createBufferedResponse(
+      204,
+      'No Content',
+      new Headers(),
+      new Uint8Array(),
+      finalUrl,
+      false,
+    )
     expect(res.text()).toBe('')
     expect(res.bytes()).toEqual(new Uint8Array())
   })
 
   it('json() throws on every call for invalid JSON (no stale cache)', () => {
     const bytes = new TextEncoder().encode('not json')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     expect(() => res.json()).toThrow()
     expect(() => res.json()).toThrow()
   })
 
   it('text() returns same reference on repeated calls', () => {
     const bytes = new TextEncoder().encode('hello')
-    const res = createBufferedResponse(200, 'OK', new Headers(), bytes)
+    const res = createBufferedResponse(200, 'OK', new Headers(), bytes, finalUrl, false)
     const first = res.text()
     const second = res.text()
     expect(first).toBe(second)

--- a/test/smoke/smoke.test.ts
+++ b/test/smoke/smoke.test.ts
@@ -1,4 +1,4 @@
-import {createRequester} from 'get-it'
+import {createRequester, isHttpError, isTimeoutError} from 'get-it'
 import {retry} from 'get-it/middleware'
 import {expect, test} from 'vitest'
 
@@ -25,4 +25,9 @@ test('the built get-it package resolves and runs a request', async () => {
 
 test('the built get-it/middleware subpath resolves', () => {
   expect(typeof retry).toBe('function')
+})
+
+test('the built error guards resolve', () => {
+  expect(typeof isHttpError).toBe('function')
+  expect(typeof isTimeoutError).toBe('function')
 })


### PR DESCRIPTION
## Summary

After integrating into `@sanity/client`, `@sanity/cli` and `sanity` modules, I am seeing a few (small) shortcomings that I wanted to address with this PR:

- Preserve Fetch `url` and `redirected` metadata on buffered, JSON, text, and stream responses
- Add structural `isHttpError()` and `isTimeoutError()` guards that work across installed get-it copies and realms
- Export `HttpErrorLike` and `TimeoutErrorLike` types for the shapes recognized by the guards

`isTimeoutError()` recognizes both get-it's headers-phase timeout and the platform `DOMException` used for total deadlines, since both are emitted by get-it.

`HttpErrorLike.response.url` and `.redirected` are optional so the guard recognizes errors from earlier v9 releases that predate the response metadata fields.

## Bundle size

- Full root export surface: + ~200 gzip bytes
- Importing both guards alone produces + ~350 gzip bytes
- `createRequester`-only bundle remains the same size, confirming guards get removed if unused


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds required `url` and `redirected` on public response types (callers with hand-rolled mocks may need updates), but behavior is a straight pass-through from fetch with well-tested guards.
> 
> **Overview**
> **Adds fetch-style `url` and `redirected` on every v9 response** (default buffered, `as: 'json' | 'text' | 'stream'`), wired from the underlying `FetchResponse` through buffering and `responseOf`. On **`HttpError`**, `error.url` remains the URL that was requested; `error.response.url` / `redirected` reflect the final response after redirects.
> 
> **Introduces structural error detection** via `isHttpError()` and `isTimeoutError()` (plus `HttpErrorLike` / `TimeoutErrorLike`), exported from the main and Node entry points. Guards match the stable v9 error shapes across duplicate package installs and realms; `HttpErrorLike.response.url` / `redirected` stay optional for older v9 errors. Docs and migration guide steer callers away from `instanceof HttpError` toward the guards.
> 
> **`HttpError` and `TimeoutError` get literal `name` types** for clearer discrimination. Tests cover metadata on all response modes, guard behavior, and built-package smoke exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72642ed7ca4e63dc48bd81a02194c24392f0ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->