### PR TITLE
fix(mock): use realm-safe checks

### DIFF
--- a/.changeset/pr-654.md
+++ b/.changeset/pr-654.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'get-it': patch
+---
+
+fix(mock): use real-safe checks

--- a/.changeset/pr-654.md
+++ b/.changeset/pr-654.md
@@ -3,4 +3,4 @@
 'get-it': patch
 ---
 
-fix(mock): use real-safe checks
+fix(mock): use realm-safe checks

--- a/src/mock/bytes.ts
+++ b/src/mock/bytes.ts
@@ -1,9 +1,27 @@
 /**
+ * Check whether a value is a `Uint8Array`, including one from another realm.
+ * @internal
+ */
+export function isUint8Array(value: unknown): value is Uint8Array {
+  return (
+    ArrayBuffer.isView(value) && Object.prototype.toString.call(value) === '[object Uint8Array]'
+  )
+}
+
+/**
+ * Check whether a value is an `ArrayBuffer`, including one from another realm.
+ * @internal
+ */
+export function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  return Object.prototype.toString.call(value) === '[object ArrayBuffer]'
+}
+
+/**
  * Check whether a value is a binary body the mock knows how to normalize to bytes.
  * @internal
  */
 export function isBinaryBody(value: unknown): value is Uint8Array | ArrayBuffer {
-  return value instanceof Uint8Array || value instanceof ArrayBuffer
+  return isUint8Array(value) || isArrayBuffer(value)
 }
 
 /**
@@ -12,7 +30,7 @@ export function isBinaryBody(value: unknown): value is Uint8Array | ArrayBuffer 
  * @internal
  */
 export function toBytes(value: Uint8Array | ArrayBuffer): Uint8Array {
-  return value instanceof Uint8Array ? value : new Uint8Array(value)
+  return isUint8Array(value) ? value : new Uint8Array(value)
 }
 
 /**

--- a/src/mock/createMockFetch.ts
+++ b/src/mock/createMockFetch.ts
@@ -6,7 +6,7 @@ import {
   normalizeFormData,
   normalizeUrlSearchParams,
 } from './body'
-import {bytesEqual, isBinaryBody, toBytes} from './bytes'
+import {bytesEqual, isArrayBuffer, isBinaryBody, isUint8Array, toBytes} from './bytes'
 import type {Diff} from './diff'
 import {diffValues} from './diff'
 import type {MockDescription} from './errors'
@@ -219,10 +219,10 @@ async function drainStream(stream: ReadableStream): Promise<Uint8Array> {
   for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
     const value: unknown = chunk.value
     // Request-body streams yield binary chunks; anything else is ignored.
-    if (value instanceof Uint8Array) {
+    if (isUint8Array(value)) {
       chunks.push(value)
       total += value.byteLength
-    } else if (value instanceof ArrayBuffer) {
+    } else if (isArrayBuffer(value)) {
       const bytes = new Uint8Array(value)
       chunks.push(bytes)
       total += bytes.byteLength
@@ -246,7 +246,7 @@ async function drainStream(stream: ReadableStream): Promise<Uint8Array> {
  */
 function matchBody(expected: unknown, actual: unknown): boolean {
   if (isBinaryBody(expected)) {
-    return actual instanceof Uint8Array && bytesEqual(toBytes(expected), actual)
+    return isUint8Array(actual) && bytesEqual(toBytes(expected), actual)
   }
   return deepMatch(expected, actual)
 }
@@ -679,7 +679,7 @@ export function createMockFetch(): MockFetch {
         } else {
           body = rawBody
         }
-      } else if (rawBody instanceof Uint8Array || rawBody instanceof ArrayBuffer) {
+      } else if (isBinaryBody(rawBody)) {
         // Store a defensive copy so the recorded body is a stable snapshot.
         // Note: a plain `new Uint8Array(...)` copy is used rather than
         // `toBytes(rawBody).slice()` because `Buffer` (a `Uint8Array`

--- a/src/mock/diff.ts
+++ b/src/mock/diff.ts
@@ -1,4 +1,4 @@
-import {bytesEqual} from './bytes'
+import {bytesEqual, isUint8Array} from './bytes'
 import {isAsymmetricMatcher, isRecord} from './matchers'
 
 /**
@@ -24,12 +24,8 @@ export function diffValues(prefix: string, expected: unknown, actual: unknown): 
 
   if (expected === actual) return []
 
-  if (expected instanceof Uint8Array || actual instanceof Uint8Array) {
-    if (
-      expected instanceof Uint8Array &&
-      actual instanceof Uint8Array &&
-      bytesEqual(expected, actual)
-    ) {
+  if (isUint8Array(expected) || isUint8Array(actual)) {
+    if (isUint8Array(expected) && isUint8Array(actual) && bytesEqual(expected, actual)) {
       return []
     }
     return [{path: prefix, expected, actual}]

--- a/src/mock/errors.ts
+++ b/src/mock/errors.ts
@@ -1,4 +1,5 @@
 import type {Diff} from './diff'
+import {isArrayBuffer, isUint8Array} from './bytes'
 
 /**
  * Description of a registered mock for error reporting.
@@ -16,8 +17,8 @@ export interface MockDescription {
 function formatValue(value: unknown): string {
   if (value === undefined) return 'undefined'
   if (typeof value === 'string') return `"${value}"`
-  if (value instanceof Uint8Array) return `Uint8Array(${value.byteLength} bytes)`
-  if (value instanceof ArrayBuffer) return `ArrayBuffer(${value.byteLength} bytes)`
+  if (isUint8Array(value)) return `Uint8Array(${value.byteLength} bytes)`
+  if (isArrayBuffer(value)) return `ArrayBuffer(${value.byteLength} bytes)`
   return String(value)
 }
 

--- a/src/mock/matchers.ts
+++ b/src/mock/matchers.ts
@@ -1,4 +1,4 @@
-import {bytesEqual, toBytes} from './bytes'
+import {bytesEqual, isUint8Array, toBytes} from './bytes'
 
 /**
  * Protocol interface for asymmetric matching, compatible with vitest/Jest.
@@ -47,10 +47,8 @@ export function deepMatch(expected: unknown, actual: unknown): boolean {
 
   if (expected === actual) return true
 
-  if (expected instanceof Uint8Array || actual instanceof Uint8Array) {
-    return (
-      expected instanceof Uint8Array && actual instanceof Uint8Array && bytesEqual(expected, actual)
-    )
+  if (isUint8Array(expected) || isUint8Array(actual)) {
+    return isUint8Array(expected) && isUint8Array(actual) && bytesEqual(expected, actual)
   }
 
   if (typeof expected !== typeof actual) return false
@@ -170,7 +168,7 @@ export function bodyBytes(expected: Uint8Array | ArrayBuffer): AsymmetricMatcher
   // member doesn't trip TypeScript's excess-property check against AsymmetricMatcher.
   const matcher = {
     asymmetricMatch(actual: unknown): boolean {
-      return actual instanceof Uint8Array && bytesEqual(expectedBytes, actual)
+      return isUint8Array(actual) && bytesEqual(expectedBytes, actual)
     },
     toString(): string {
       return `bodyBytes(${expectedBytes.byteLength} bytes)`

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -1,3 +1,5 @@
+import {isUint8Array} from './bytes'
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -47,15 +49,13 @@ export class StreamBody {
     // `Buffer` inputs: `Buffer` (a `Uint8Array` subclass) overrides `slice()`
     // to return a view sharing the same backing memory, which would leave
     // the snapshot unprotected against later mutation of the source buffer.
-    const copiedParts = parts.map((part) =>
-      part instanceof Uint8Array ? new Uint8Array(part) : part,
-    )
+    const copiedParts = parts.map((part) => (isUint8Array(part) ? new Uint8Array(part) : part))
     this.script = copiedParts
   }
 }
 
 function assertValidPart(part: StreamPart, index: number, parts: ReadonlyArray<StreamPart>): void {
-  if (typeof part === 'string' || part instanceof Uint8Array) return
+  if (typeof part === 'string' || isUint8Array(part)) return
   if (part.kind === 'delay') {
     if (!(part.ms >= 0)) {
       throw new TypeError(`streamBody(): invalid delay at index ${index}: ${part.ms}`)
@@ -227,7 +227,7 @@ export function streamFromScript(
           controller.enqueue(encoder.encode(part))
           return
         }
-        if (part instanceof Uint8Array) {
+        if (isUint8Array(part)) {
           controller.enqueue(new Uint8Array(part))
           return
         }

--- a/test/mock/createMockFetch.test.ts
+++ b/test/mock/createMockFetch.test.ts
@@ -1,4 +1,4 @@
-import {createRequester} from 'get-it'
+import {createRequester, isTimeoutError} from 'get-it'
 import {retry} from 'get-it/middleware'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -1123,9 +1123,8 @@ describe('createMockFetch', () => {
       } catch (err) {
         error = err
       }
-      expect(error).toBeInstanceOf(DOMException)
-      if (!(error instanceof DOMException)) throw new Error('expected a DOMException')
-      expect(error.name).toBe('AbortError')
+      expect(error).toBe(controller.signal.reason)
+      expect(error).toMatchObject({name: 'AbortError'})
     })
 
     it('propagates a custom abort reason', async () => {
@@ -1193,9 +1192,9 @@ describe('createMockFetch', () => {
       // Should reject well before the 1000ms delay completes
       expect(elapsed).toBeLessThan(500)
 
-      // AbortSignal.timeout() produces a DOMException with name 'TimeoutError'
-      expect(error).toBeInstanceOf(Error)
-      if (!(error instanceof Error)) throw error
+      // The total deadline produces a DOMException with name 'TimeoutError'.
+      expect(isTimeoutError(error)).toBe(true)
+      if (!isTimeoutError(error)) throw new Error('expected timeout error')
       expect(error.name).toBe('TimeoutError')
     })
   })

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,4 +1,4 @@
-import {createRequester, type FetchInit, TimeoutError} from 'get-it'
+import {createRequester, type FetchInit, isTimeoutError, TimeoutError} from 'get-it'
 import {describe, expect, it, vi} from 'vitest'
 import {resolveTimeout} from '../src/createRequester'
 
@@ -210,8 +210,8 @@ describe('structured timeout behavior', () => {
       () => null,
       (reason: unknown) => reason,
     )
-    expect(err).toBeInstanceOf(Error)
-    if (!(err instanceof Error)) throw new Error('expected Error')
+    expect(isTimeoutError(err)).toBe(true)
+    if (!isTimeoutError(err)) throw new Error('expected timeout error')
     expect(err.name).toBe('TimeoutError')
     expect(err.message).toBe('The operation was aborted due to timeout')
     // The losing fetch keeps running to completion in the background; let it
@@ -247,8 +247,8 @@ describe('structured timeout behavior', () => {
       () => null,
       (reason: unknown) => reason,
     )
-    expect(err).toBeInstanceOf(Error)
-    if (!(err instanceof Error)) throw new Error('expected Error')
+    expect(isTimeoutError(err)).toBe(true)
+    if (!isTimeoutError(err)) throw new Error('expected timeout error')
     expect(err.name).toBe('TimeoutError')
     // Buffering continues in the background after the race is lost; let the
     // body finish to prove its settlement is swallowed.


### PR DESCRIPTION
When mixing VM realms like jsdom does (injecting Node's Buffer, AbortController etc, but supplying separate Uint8Array, DOMException etc), some of the mock assertions would fail. This PR makes it use a realm-safe approach, and also changes a few `instanceof` checks in the timeout tests to use the new `isTimeoutError` so we don't have to compare against DOMException (also not realm-safe).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted mock and test changes with no auth or production request-path impact; behavior should match prior semantics in a single realm while fixing cross-realm false negatives.
> 
> **Overview**
> Fixes mock fetch behavior when **Node and jsdom (or other) realms mix** the same binary types—e.g. Node `Buffer` vs a separate global `Uint8Array`—where `instanceof` could falsely reject valid bodies and break matching, diffing, and stream scripts.
> 
> Adds internal **`isUint8Array`** and **`isArrayBuffer`** helpers in `bytes.ts` (`ArrayBuffer.isView` + `Object.prototype.toString`) and wires them through **`isBinaryBody`**, **`toBytes`**, request-body draining, **`matchBody`**, **`deepMatch`**, **`bodyBytes`**, diffs, error formatting, and **`streamBody`** so binary handling stays consistent across realms.
> 
> Test updates align with the same idea: abort expectations use **`controller.signal.reason`** instead of **`DOMException`**, and timeout failures use **`isTimeoutError`** rather than brittle `instanceof` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88362411b7533295e600010e1860e060f1a7cce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->