### PR TITLE
ci: add bundle size checks

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -1,0 +1,28 @@
+name: Bundle Stats
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bundle-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          cache: pnpm
+          node-version: 24
+      - run: pnpm install --frozen-lockfile
+      - uses: rexxars/bundle-stats@fc60b16fb61b93ad86196682e36f013bc8aef292 # merged v2

--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -25,4 +25,4 @@ jobs:
           cache: pnpm
           node-version: 24
       - run: pnpm install --frozen-lockfile
-      - uses: rexxars/bundle-stats@4bf52e3d63ba6ebe8be19dce75bd0d5b2d2cce20 # v2 baseline fix
+      - uses: rexxars/bundle-stats@4c3c939363da017fdb1a44b2de0c2927a0c95020 # v2

--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -25,4 +25,4 @@ jobs:
           cache: pnpm
           node-version: 24
       - run: pnpm install --frozen-lockfile
-      - uses: rexxars/bundle-stats@fc60b16fb61b93ad86196682e36f013bc8aef292 # merged v2
+      - uses: rexxars/bundle-stats@4bf52e3d63ba6ebe8be19dce75bd0d5b2d2cce20 # v2 baseline fix

--- a/bundle-stats.config.ts
+++ b/bundle-stats.config.ts
@@ -1,0 +1,15 @@
+export default {
+  packages: [
+    {
+      root: '.',
+      scenarios: {
+        exports: false,
+        bins: false,
+        entries: {
+          'readme-minimal': './test/bundle/readme-minimal.ts',
+        },
+      },
+      importTime: false,
+    },
+  ],
+}

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["test/deno/smoke.ts"],
+  "entry": ["bundle-stats.config.ts", "test/bundle/readme-minimal.ts", "test/deno/smoke.ts"],
   "vitest": {
     "config": ["vitest.config.ts", "test/config/vitest.*.config.ts"]
   },

--- a/test/bundle/readme-minimal.ts
+++ b/test/bundle/readme-minimal.ts
@@ -1,0 +1,8 @@
+import {createRequester} from 'get-it'
+
+const request = createRequester({
+  base: 'https://api.example.com',
+})
+
+const users = await request('/users')
+console.log(users.json())


### PR DESCRIPTION
## Summary

- Add Bundle Stats to pull requests targeting `main`.
- Measure the README's minimal `createRequester()` example as one named consumer scenario.
- Disable automatic export and bin scenarios so the report stays focused on the consumer bundle.
- Register the workflow-only files as Knip entry points.

## Notes

- The action is pinned to commit `4c3c939`, the commit referenced by the published `v2` tag.
- The first workflow run reports the scenario as added and establishes the baseline for later pull requests.
- No changeset is included because this only changes CI and test fixtures.

## Checks

- `pnpm run build`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run --reporter=agent`: 508 tests passed
- Local Bundle Stats measurement: 17,118 B raw and 5,508 B gzip
- `pnpm run knip`: the new entries are clean; the command still reports the existing `pkg-pr-new` binary and `NormalizedFile` export findings from `main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only: new GitHub Action with PR comment permissions and a small fixture. No library or runtime behavior changes.
> 
> **Overview**
> Adds a **Bundle Stats** GitHub Action on PRs to `main` so reviewers can see consumer bundle size vs the previous baseline.
> 
> The report measures a single named scenario (`readme-minimal`) that mirrors the README’s `createRequester()` example. Automatic export/bin scenarios and import-time measurement are turned off so the comment stays focused.
> 
> Knip is updated to treat the new config and fixture as entry points. The action is pinned to a specific `v2` commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4ec996662b048b6201b22df94850a9e39dd00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->