### PR TITLE
chore: batch dev dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,28 @@
       "matchPackageNames": ["debug", "follow-redirects", "parse-headers"],
       "rangeStrategy": "bump",
       "semanticCommitType": "fix"
+    },
+    {
+      "description": "Batch non-major devDependency updates into a single PR, instead of one PR per package",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": [
+        "bump",
+        "digest",
+        "lockfileUpdate",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "replacement",
+        "rollback"
+      ],
+      "groupName": "dev dependencies (non-major)",
+      "groupSlug": "dev-deps-non-major"
+    },
+    {
+      "description": "`undici-types` is a pnpm override that must stay major-aligned with `undici`, so update them together",
+      "matchPackageNames": ["undici", "undici-types"],
+      "groupName": "undici"
     }
   ]
 }


### PR DESCRIPTION
Minor; gets annoying to approve every little dev dependency update in isolation. I'd rather get one PR where the tests can run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Renovate automation config changes; no runtime or build logic is modified.
> 
> **Overview**
> Extends **Renovate** `packageRules` so dependency PR noise drops without changing application code.
> 
> **Non-major `devDependencies`** (patch, minor, lockfile, pin, etc.) are now grouped into a single PR named **dev dependencies (non-major)** instead of one PR per package—matching the intent to run tests once per batch rather than approve many small updates.
> 
> **`undici` and `undici-types`** are grouped under **undici** so Renovate keeps the pnpm override aligned with the runtime `undici` major when both bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc4a0797605776445ef3313cb38a18394180ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->