### PR TITLE
feat: add options.maxResponseSize

### DIFF
--- a/.changeset/salty-bats-hope.md
+++ b/.changeset/salty-bats-hope.md
@@ -1,0 +1,5 @@
+---
+"get-it": minor
+---
+
+Add options.maxResponseSize to support throwing an error when response size is too large

--- a/src/_exports/index.node.ts
+++ b/src/_exports/index.node.ts
@@ -42,7 +42,7 @@ export function createRequester(
 }
 
 // Re-export everything from core
-export {HttpError, TimeoutError} from '../errors'
+export {HttpError, ResponseExceededMaxSizeError, TimeoutError} from '../errors'
 export {isHttpError, isTimeoutError} from '../errorGuards'
 export type {HttpErrorLike, TimeoutErrorLike} from '../errorGuards'
 export type {

--- a/src/_exports/index.ts
+++ b/src/_exports/index.ts
@@ -1,5 +1,5 @@
 export {createRequester} from '../createRequester'
-export {HttpError, TimeoutError} from '../errors'
+export {HttpError, ResponseExceededMaxSizeError, TimeoutError} from '../errors'
 export {isHttpError, isTimeoutError} from '../errorGuards'
 export type {HttpErrorLike, TimeoutErrorLike} from '../errorGuards'
 export type {

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -1,4 +1,4 @@
-import {HttpError, TimeoutError} from './errors'
+import {HttpError, ResponseExceededMaxSizeError, TimeoutError} from './errors'
 import {createBufferedResponse} from './response'
 import type {
   BufferedResponse,
@@ -48,6 +48,7 @@ export function createRequester(
   const instanceBase = options?.base
   const instanceHttpErrors = options?.httpErrors
   const instanceTimeout = options?.timeout
+  const instanceMaxResponseSize = validateMaxResponseSize(options?.maxResponseSize)
   const instanceCredentials = options?.credentials
 
   // Separate middleware into transforms and wrappers by shape
@@ -195,7 +196,11 @@ export function createRequester(
     // Once buffering settles the deadline is spent either way — release its
     // timers.
     try {
-      return await raceDeadline(bufferAndCheck(response, httpErrors, url, method), totalDeadline)
+      rejectDeclaredResponseTooLarge(response, opts.maxResponseSize)
+      return await raceDeadline(
+        bufferAndCheck(response, httpErrors, url, method, opts.maxResponseSize),
+        totalDeadline,
+      )
     } finally {
       clearDeadline()
     }
@@ -239,6 +244,7 @@ export function createRequester(
     // Capture the raw fetch response so we can extract the stream after
     // the wrapping middleware chain completes.
     let capturedResponse: FetchResponse | undefined
+    let capturedMaxResponseSize: number | undefined
 
     async function getItStreamed(reqOpts: RequestOptions): Promise<BufferedResponse> {
       const fetchFn: FetchFunction = reqOpts.fetch ?? instanceFetch ?? globalThis.fetch
@@ -248,10 +254,17 @@ export function createRequester(
       )
       const httpErrors = reqOpts.httpErrors ?? instanceHttpErrors ?? true
 
+      try {
+        rejectDeclaredResponseTooLarge(response, reqOpts.maxResponseSize)
+      } catch (error) {
+        clearDeadline()
+        throw error
+      }
+
       if (httpErrors && response.status >= 400) {
         try {
           return await raceDeadline(
-            bufferAndCheck(response, httpErrors, url, method),
+            bufferAndCheck(response, httpErrors, url, method, reqOpts.maxResponseSize),
             totalDeadline,
           )
         } finally {
@@ -267,6 +280,7 @@ export function createRequester(
       // its timer must stay armed.
       if (totalDeadline !== undefined) clearDeadline()
       capturedResponse = response
+      capturedMaxResponseSize = reqOpts.maxResponseSize
       return createBufferedResponse(
         response.status,
         response.statusText,
@@ -286,13 +300,10 @@ export function createRequester(
       throw new Error('Stream response was not captured')
     }
 
-    const streamBody =
-      capturedResponse.body ??
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.close()
-        },
-      })
+    const streamBody = limitResponseBody(
+      capturedResponse.body ?? emptyResponseBody(),
+      capturedMaxResponseSize,
+    )
 
     return responseOf(capturedResponse, streamBody)
   }
@@ -318,6 +329,7 @@ export function createRequester(
       ...raw,
       url,
       headers: mergeHeaders(options?.headers, raw.headers),
+      maxResponseSize: validateMaxResponseSize(raw.maxResponseSize ?? instanceMaxResponseSize),
     }
 
     switch (opts.as ?? options?.as) {
@@ -596,9 +608,12 @@ async function bufferAndCheck(
   httpErrors: boolean,
   requestUrl: string,
   requestMethod: string,
+  maxResponseSize: number | undefined,
 ): Promise<BufferedResponse> {
-  const arrayBuffer = await response.arrayBuffer()
-  const bytes = new Uint8Array(arrayBuffer)
+  const bytes =
+    maxResponseSize === undefined || maxResponseSize === -1
+      ? new Uint8Array(await response.arrayBuffer())
+      : await readResponseBody(response.body, maxResponseSize)
   const buffered = createBufferedResponse(
     response.status,
     response.statusText,
@@ -631,6 +646,106 @@ async function bufferAndCheck(
   }
 
   return buffered
+}
+
+// TODO: Replace with ReadableStream.from([]) once it's baseline
+function emptyResponseBody(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close()
+    },
+  })
+}
+
+function rejectDeclaredResponseTooLarge(
+  response: FetchResponse,
+  maxResponseSize: number | undefined,
+): void {
+  const limit = validateMaxResponseSize(maxResponseSize)
+  if (limit === undefined || response.body === null) return
+
+  const contentEncoding = response.headers.get('content-encoding')
+  if (contentEncoding !== null && contentEncoding.trim().toLowerCase() !== 'identity') return
+
+  const contentLength = response.headers.get('content-length')
+  if (contentLength === null) return
+
+  const normalizedLength = contentLength.trim()
+  if (!/^\d+$/.test(normalizedLength) || Number(normalizedLength) <= limit) return
+
+  const error = new ResponseExceededMaxSizeError()
+  response.body.cancel(error).catch(() => {})
+  throw error
+}
+
+function limitResponseBody(
+  body: ReadableStream<Uint8Array>,
+  maxResponseSize: number | undefined,
+): ReadableStream<Uint8Array> {
+  const limit = validateMaxResponseSize(maxResponseSize)
+  if (limit === undefined) return body
+
+  const reader = body.getReader()
+  let bytesRead = 0
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read()
+        if (result.done) {
+          controller.close()
+          return
+        }
+
+        bytesRead += result.value.byteLength
+        if (bytesRead > limit) {
+          const error = new ResponseExceededMaxSizeError()
+          reader.cancel(error).catch(() => {})
+          controller.error(error)
+          return
+        }
+
+        controller.enqueue(result.value)
+      } catch (error) {
+        controller.error(error)
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+}
+
+async function readResponseBody(
+  body: ReadableStream<Uint8Array> | null,
+  maxResponseSize: number,
+): Promise<Uint8Array> {
+  const reader = limitResponseBody(body ?? emptyResponseBody(), maxResponseSize).getReader()
+  const chunks: Uint8Array[] = []
+  let bytesRead = 0
+  while (true) {
+    const result = await reader.read()
+    if (result.done) break
+
+    bytesRead += result.value.byteLength
+    chunks.push(result.value)
+  }
+
+  const bytes = new Uint8Array(bytesRead)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+/** @returns A positive integer or `undefined`. */
+function validateMaxResponseSize(maxResponseSize: number | undefined): number | undefined {
+  if (maxResponseSize === undefined || maxResponseSize === -1) return undefined
+  if (!Number.isInteger(maxResponseSize) || maxResponseSize < 0) {
+    throw new TypeError('maxResponseSize must be a non-negative integer or -1')
+  }
+  return maxResponseSize
 }
 
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -86,3 +86,18 @@ export class TimeoutError extends Error {
     this.code = 'ETIMEDOUT'
   }
 }
+
+/**
+ * An error thrown when a response body exceeds the configured maximum size.
+ *
+ * @public
+ */
+export class ResponseExceededMaxSizeError extends Error {
+  /** Stable error discriminator. */
+  declare name: 'ResponseExceededMaxSizeError'
+
+  constructor() {
+    super('Response content exceeded max size')
+    this.name = 'ResponseExceededMaxSizeError'
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,11 @@ export interface RequesterOptions {
    * 120 000 ms total.
    */
   timeout?: number | false | TimeoutOptions
+  /**
+   * Maximum response body size in bytes. The request is aborted if the body
+   * exceeds this size. Set to `-1` to disable. Disabled by default.
+   */
+  maxResponseSize?: number
   /** Custom fetch implementation. In Node.js, defaults to an undici-backed fetch. */
   fetch?: FetchFunction
   /** Credentials mode forwarded to fetch (browser-only). */
@@ -216,6 +221,11 @@ export interface RequestOptions {
    * instance value wholesale — fields are not merged.
    */
   timeout?: number | false | TimeoutOptions
+  /**
+   * Maximum response body size in bytes. Overrides the requester default.
+   * Set to `-1` to disable.
+   */
+  maxResponseSize?: number
   /** Override the instance-level `fetch` for this request. */
   fetch?: FetchFunction
   /** Credentials mode forwarded to fetch (browser-only). */

--- a/test/max-response-size.test.ts
+++ b/test/max-response-size.test.ts
@@ -1,0 +1,129 @@
+import {createRequester, ResponseExceededMaxSizeError} from 'get-it'
+import {describe, expect, it} from 'vitest'
+
+function response(...chunks: Uint8Array[]): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const chunk = chunks.shift()
+        if (chunk) {
+          controller.enqueue(chunk)
+        } else {
+          controller.close()
+        }
+      },
+    }),
+  )
+}
+
+const encode = (value: string) => new TextEncoder().encode(value)
+
+describe('maxResponseSize', () => {
+  it('rejects buffered responses that exceed the per-request limit', async () => {
+    const request = createRequester({fetch: async () => response(encode('hello'), encode('!'))})
+
+    const result = request({url: 'https://example.com', maxResponseSize: 5})
+
+    await expect(result).rejects.toMatchObject({
+      name: 'ResponseExceededMaxSizeError',
+      message: 'Response content exceeded max size',
+    })
+    await expect(result).rejects.toBeInstanceOf(ResponseExceededMaxSizeError)
+  })
+
+  it('allows a response whose size exactly equals the limit', async () => {
+    const request = createRequester({fetch: async () => response(encode('hello'))})
+
+    const result = await request({url: 'https://example.com', maxResponseSize: 5})
+
+    expect(result.text()).toBe('hello')
+  })
+
+  it('rejects from Content-Length before reading the body', async () => {
+    let cancellationReason: unknown
+    const body = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancellationReason = reason
+      },
+    })
+    const request = createRequester({
+      fetch: async () => new Response(body, {headers: {'content-length': '6'}}),
+    })
+
+    await expect(request({url: 'https://example.com', maxResponseSize: 5})).rejects.toBeInstanceOf(
+      ResponseExceededMaxSizeError,
+    )
+    expect(cancellationReason).toBeInstanceOf(ResponseExceededMaxSizeError)
+  })
+
+  it('does not compare an encoded Content-Length with the decoded body limit', async () => {
+    const request = createRequester({
+      fetch: async () =>
+        new Response(encode('hello'), {
+          headers: {'content-encoding': 'gzip', 'content-length': '100'},
+        }),
+    })
+
+    const result = await request({url: 'https://example.com', maxResponseSize: 5})
+
+    expect(result.text()).toBe('hello')
+  })
+
+  it('uses the requester default and allows a per-request override', async () => {
+    const request = createRequester({
+      fetch: async () => response(encode('hello')),
+      maxResponseSize: 4,
+    })
+
+    await expect(request('https://example.com')).rejects.toBeInstanceOf(
+      ResponseExceededMaxSizeError,
+    )
+    const unbounded = await request({url: 'https://example.com', maxResponseSize: -1})
+    expect(unbounded.text()).toBe('hello')
+  })
+
+  it('errors and cancels a streaming response when it crosses the limit', async () => {
+    let cancellationReason: unknown
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encode('hello'))
+        controller.enqueue(encode('!'))
+      },
+      cancel(reason) {
+        cancellationReason = reason
+      },
+    })
+    const request = createRequester({fetch: async () => new Response(body)})
+    const result = await request({
+      url: 'https://example.com',
+      as: 'stream',
+      maxResponseSize: 5,
+    })
+    const reader = result.body.getReader()
+
+    await expect(reader.read()).resolves.toMatchObject({value: encode('hello'), done: false})
+    await expect(reader.read()).rejects.toBeInstanceOf(ResponseExceededMaxSizeError)
+    expect(cancellationReason).toBeInstanceOf(ResponseExceededMaxSizeError)
+  })
+
+  it('rejects invalid limits', async () => {
+    let fetchCalled = false
+    const request = createRequester({
+      fetch: async () => {
+        fetchCalled = true
+        return response(encode('hello'))
+      },
+    })
+
+    await expect(request({url: 'https://example.com', maxResponseSize: -2})).rejects.toThrow(
+      'maxResponseSize must be a non-negative integer or -1',
+    )
+    await expect(request({url: 'https://example.com', maxResponseSize: 1.5})).rejects.toThrow(
+      'maxResponseSize must be a non-negative integer or -1',
+    )
+    expect(fetchCalled).toBe(false)
+    expect(() => createRequester({maxResponseSize: -2})).toThrow(
+      'maxResponseSize must be a non-negative integer or -1',
+    )
+  })
+})


### PR DESCRIPTION
An [Undici-inspired](https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md) API for limiting the size of response bodies. Use case is that we want to allow clients in MCP to run arbitrary GROQ queries, but need a way to bail out early if the query is huge (ex. Content Lake can allow up to 500MB queries).

Adds `options.maxResponseSize`:
- Defaults to `undefined` (disabled)
- Can be set to `-1` to disable
- Can be set to a non-negative integer to set the maximum allowed response size in bytes

Responses that are too big will throw `ResponseExceededMaxSizeError`

Contributes to AIGRO-5474

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core response buffering and streaming in the request path; misconfiguration or edge cases around Content-Length vs encoded bodies could affect callers that enable the limit.
> 
> **Overview**
> Adds optional **`maxResponseSize`** on `createRequester` and per-request options so callers can cap how many bytes of a response body are accepted (default off; **`-1`** disables). Oversized bodies throw the new exported **`ResponseExceededMaxSizeError`**.
> 
> Enforcement is wired through buffered reads and **`as: 'stream'`**: instance and per-request limits are validated and merged, **`Content-Length`** can fail fast when it exceeds the limit (skipped for non-identity **`content-encoding`**), and streaming bodies are wrapped so reads error and cancel once cumulative size passes the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55f142c3c8242792907ed7ed7a697455ad3d646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->