### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npx ls-engines
-      - run: npm run build
+      # This build only exists to give the tests something to run against, and
+      # publint packs the tarball with the package manager it detects (pnpm),
+      # which may not run on the version under test. The `build` job publints.
+      - run: npm run build -- --no-publint
       - run: npm test
 
   test-browser:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
           - os: ubuntu-latest
             platform: Ubuntu
             node: '22.12.0'
+            # pnpm 11 itself requires Node.js >=22.13, so install dependencies on
+            # 22.13 and switch back to 22.12.0 before building and testing.
+            installNode: '22.13'
           - os: ubuntu-latest
             platform: Ubuntu
             node: '24'
@@ -69,11 +72,18 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           cache: pnpm
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.installNode || matrix.node }}
       - run: pnpm install
+      # Re-pin to the version under test, in case dependencies had to be installed
+      # on a newer one. Scripts run through `npm` since the pnpm CLI may not be
+      # able to run on it - the dependencies are already installed at this point.
+      - uses: actions/setup-node@v7
+        if: matrix.installNode
+        with:
+          node-version: ${{ matrix.node }}
       - run: npx ls-engines
-      - run: pnpm run build
-      - run: pnpm test
+      - run: npm run build
+      - run: npm test
 
   test-browser:
     name: 'Test: Chrome, Firefox, WebKit'

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,5 @@
   "entry": ["bundle-stats.config.ts", "test/bundle/readme-minimal.ts", "test/deno/smoke.ts"],
   "vitest": {
     "config": ["vitest.config.ts", "test/config/vitest.*.config.ts"]
-  },
-  "ignoreBinaries": ["scripts/report-size.sh"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -119,5 +119,5 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "packageManager": "pnpm@10.34.1"
+  "packageManager": "pnpm@11.25.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 allowBuilds:
   esbuild: true
+  # Swaps workerd's JS launcher for the platform binary it would otherwise
+  # resolve on every run.
+  workerd: true
 overrides:
   # @types/node bundles undici-types@6, but we depend on undici@7 whose fetch
   # types use the newer (iterator-helper-bearing) FormData/Headers. Align the

--- a/src/mock/body.ts
+++ b/src/mock/body.ts
@@ -2,7 +2,7 @@
  * A file/blob entry from a normalized `FormData` body.
  * @internal
  */
-export interface NormalizedFile {
+interface NormalizedFile {
   name: string
   type: string
   size: number


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly tooling and CI; the only library surface change is making an already-`@internal` type non-exported, with no in-repo consumers of that export.
> 
> **Overview**
> **Upgrades the repo to pnpm 11.25.0** and adjusts CI and workspace config so installs and tests still pass on the declared minimum Node **22.12.0**.
> 
> The Node matrix job for **22.12.0** now installs dependencies on **22.13** (pnpm 11’s floor), switches Node back to **22.12.0**, then runs **`npm run build -- --no-publint`** and **`npm test`** so build/test don’t depend on the pnpm CLI or publint’s pnpm-based pack step on the version under test. **`pnpm-workspace.yaml`** enables **`allowBuilds.workerd`** for pnpm 11’s native workerd binary behavior. **`knip.json`** drops **`ignoreBinaries`** for `scripts/report-size.sh`. **`NormalizedFile`** in `src/mock/body.ts` is no longer exported (still used only via **`FormValue`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a276eea63159b0f09cabcc3582547d1bacfbc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->