### PR TITLE
fix: replace the any-signal dependency with a get-it/any-signal ponyfill (SAPP-4426)

### DIFF
--- a/.changeset/safari-17-any-signal.md
+++ b/.changeset/safari-17-any-signal.md
@@ -1,0 +1,5 @@
+---
+'get-it': patch
+---
+
+fall back to a small `AbortSignal.any()` ponyfill on Safari 17.0–17.3, which has no `AbortSignal.any()`, so requests with both a timeout and a caller `signal` no longer throw there; the ponyfill is exported as `get-it/any-signal`

--- a/README.md
+++ b/README.md
@@ -186,7 +186,15 @@ const promise = request({url: '/slow', signal: controller.signal})
 controller.abort()
 ```
 
-get-it combines the timeout signal and your signal automatically with [`any-signal`](https://www.npmjs.com/package/any-signal), which works on Safari 17.0–17.3 where `AbortSignal.any()` does not exist. Rejection-only timeouts (`timeout: {signal: false}`) are the exception. For these, get-it sends your signal without a change.
+get-it combines the timeout signal and your signal automatically with `AbortSignal.any()`. Safari 17.0–17.3 has no `AbortSignal.any()`, so get-it uses the native function where it exists and a small fallback where it does not. The fallback is exported as `get-it/any-signal` for your own code:
+
+```ts
+import {anySignal} from 'get-it/any-signal'
+
+const signal = anySignal([controller.signal, AbortSignal.timeout(5000)])
+```
+
+Rejection-only timeouts (`timeout: {signal: false}`) are the exception. For these, get-it sends your signal without a change.
 
 ## Middleware
 
@@ -304,13 +312,14 @@ For the full documentation, read [docs/mock.md](docs/mock.md). It covers respons
 
 ## Entry points
 
-| Import              | Purpose                                                     |
-| ------------------- | ----------------------------------------------------------- |
-| `get-it`            | Core (it selects the Node variant with conditional exports) |
-| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`     |
-| `get-it/node`       | `createNodeFetch()` for your own undici dispatcher          |
-| `get-it/mock`       | `createMockFetch()` and matchers for testing                |
-| `get-it/vitest`     | Custom vitest matchers for mock assertions                  |
+| Import              | Purpose                                                      |
+| ------------------- | ------------------------------------------------------------ |
+| `get-it`            | Core (it selects the Node variant with conditional exports)  |
+| `get-it/middleware` | `retry`, `debug`, `isRetryableRequest`, `getRetryDelay`      |
+| `get-it/node`       | `createNodeFetch()` for your own undici dispatcher           |
+| `get-it/mock`       | `createMockFetch()` and matchers for testing                 |
+| `get-it/vitest`     | Custom vitest matchers for mock assertions                   |
+| `get-it/any-signal` | `anySignal()`, `AbortSignal.any()` with a Safari 17 fallback |
 
 ## Migrating from v8
 

--- a/docs/MIGRATION-v9.md
+++ b/docs/MIGRATION-v9.md
@@ -522,7 +522,7 @@ const request = createRequester({
 })
 ```
 
-get-it combines the timeout signal and your `signal` automatically with `AbortSignal.any()`.
+get-it combines the timeout signal and your `signal` automatically with `AbortSignal.any()`, with a fallback for Safari 17.0–17.3 (also exported as `get-it/any-signal`).
 
 **React Native**: v8 detected React Native (`navigator.product === 'ReactNative'`) and used a default timeout of 60 seconds. v9 uses 120 seconds in all runtimes. To get the shorter timeout again:
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "bun": "./dist/index.node.js",
       "default": "./dist/index.js"
     },
+    "./any-signal": "./dist/any-signal.js",
     "./middleware": "./dist/middleware.js",
     "./mock": "./dist/mock.js",
     "./node": "./dist/node.js",
@@ -76,7 +77,6 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.check.json && tsc --noEmit -p tsconfig.check-node.json"
   },
   "dependencies": {
-    "any-signal": "^4.2.0",
     "undici": "^7.29.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
 
   .:
     dependencies:
-      any-signal:
-        specifier: ^4.2.0
-        version: 4.2.0
       undici:
         specifier: ^7.29.0
         version: 7.29.0
@@ -2382,10 +2379,6 @@ packages:
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
-
-  any-signal@4.2.0:
-    resolution: {integrity: sha512-LndMvYuAPf4rC195lk7oSFuHOYFpOszIYrNYv0gHAvz+aEhE9qPZLhmrIz5pXP2BSsPOXvsuHDXEGaiQhIh9wA==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -5970,8 +5963,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansis@4.3.1: {}
-
-  any-signal@4.2.0: {}
 
   argparse@1.0.10:
     dependencies:

--- a/src/_exports/any-signal.ts
+++ b/src/_exports/any-signal.ts
@@ -1,0 +1,1 @@
+export {anySignal} from '../anySignal'

--- a/src/anySignal.ts
+++ b/src/anySignal.ts
@@ -1,0 +1,29 @@
+/**
+ * Returns a signal that aborts as soon as any of `signals` aborts, with that
+ * signal's reason. Delegates to `AbortSignal.any` where it exists (Node.js,
+ * Safari 17.4+) and falls back to abort listeners on Safari 17.0–17.3, which
+ * has no `AbortSignal.any`.
+ *
+ * The fallback keeps its listeners on the source signals until one of them
+ * aborts. Runtimes with a native `AbortSignal.any` never take that path.
+ *
+ * @public
+ */
+export function anySignal(signals: AbortSignal[]): AbortSignal {
+  if (typeof AbortSignal.any === 'function') return AbortSignal.any(signals)
+
+  const controller = new AbortController()
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason)
+      return controller.signal
+    }
+  }
+
+  const onAbort = () => {
+    controller.abort(signals.find((signal) => signal.aborted)?.reason)
+    for (const signal of signals) signal.removeEventListener('abort', onAbort)
+  }
+  for (const signal of signals) signal.addEventListener('abort', onAbort)
+  return controller.signal
+}

--- a/src/createRequester.ts
+++ b/src/createRequester.ts
@@ -1,5 +1,4 @@
-import {anySignal} from 'any-signal'
-
+import {anySignal} from './anySignal'
 import {HttpError, TimeoutError} from './errors'
 import {createBufferedResponse} from './response'
 import type {

--- a/src/mock/streamBody.ts
+++ b/src/mock/streamBody.ts
@@ -1,5 +1,4 @@
-import {anySignal} from 'any-signal'
-
+import {anySignal} from '../anySignal'
 import {isUint8Array} from './bytes'
 
 // ---------------------------------------------------------------------------

--- a/test/any-signal.test.ts
+++ b/test/any-signal.test.ts
@@ -1,4 +1,5 @@
 import {createRequester, type FetchInit, isTimeoutError, TimeoutError} from 'get-it'
+import {anySignal} from 'get-it/any-signal'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 import {streamBody, streamFromScript, streamStall} from '../src/mock/streamBody'
 
@@ -54,6 +55,53 @@ function settle(promise: Promise<unknown>): Promise<unknown> {
 }
 
 function itCombinesSignals() {
+  it('aborts once, with the reason of the signal that aborted first', () => {
+    const a = new AbortController()
+    const b = new AbortController()
+    const combined = anySignal([a.signal, b.signal])
+    expect(combined).toBeInstanceOf(AbortSignal)
+    expect(combined.aborted).toBe(false)
+
+    let events = 0
+    combined.addEventListener('abort', () => events++)
+    const reason = new Error('b aborted')
+    b.abort(reason)
+    expect(combined.aborted).toBe(true)
+    expect(combined.reason).toBe(reason)
+    expect(events).toBe(1)
+
+    a.abort(new Error('too late'))
+    expect(combined.reason).toBe(reason)
+    expect(events).toBe(1)
+  })
+
+  it('is aborted from the start when an input is already aborted', () => {
+    const live = new AbortController()
+    const dead = new AbortController()
+    const reason = new Error('already aborted')
+    dead.abort(reason)
+    const combined = anySignal([live.signal, dead.signal])
+    expect(combined.aborted).toBe(true)
+    expect(combined.reason).toBe(reason)
+  })
+
+  it('uses the first aborted input when several are already aborted', () => {
+    const first = new AbortController()
+    const second = new AbortController()
+    first.abort(new Error('first'))
+    second.abort(new Error('second'))
+    const combined = anySignal([first.signal, second.signal])
+    expect(combined.reason).toBe(first.signal.reason)
+  })
+
+  it('aborting one input leaves the other inputs untouched', () => {
+    const a = new AbortController()
+    const b = new AbortController()
+    anySignal([a.signal, b.signal])
+    a.abort()
+    expect(b.signal.aborted).toBe(false)
+  })
+
   it('a caller signal cancels a request that also has a total timeout', async () => {
     const observed = createSignalObservingFetch()
     const request = createRequester({timeout: {total: 30_000}, fetch: observed.fetch})

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -14,6 +14,7 @@
 
     "paths": {
       "get-it": ["./src/_exports/index.ts"],
+      "get-it/any-signal": ["./src/_exports/any-signal.ts"],
       "get-it/middleware": ["./src/_exports/middleware.ts"],
       "get-it/node": ["./src/_exports/node.ts"],
       "get-it/mock": ["./src/_exports/mock.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export const sharedConfig = {
   ],
   reporters: process.env['GITHUB_ACTIONS'] ? ['default', 'github-actions'] : 'default',
   alias: {
+    'get-it/any-signal': new URL('./src/_exports/any-signal.ts', import.meta.url).pathname,
     'get-it/middleware': new URL('./src/_exports/middleware.ts', import.meta.url).pathname,
     'get-it/node': new URL('./src/_exports/node.ts', import.meta.url).pathname,
     'get-it/mock': new URL('./src/_exports/mock.ts', import.meta.url).pathname,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linear: [SAPP-4426](https://linear.app/sanity/issue/SAPP-4426). Follow-up to #670, which was merged and released as 9.5.3 before this pivot.

Reviewer: @rexxars. The automation token got a 403 on the review-request API, so this is a mention rather than a formal request.

## Why pivot

#670 pulled in the `any-signal` npm package. That package attaches strong `abort` listeners to every source signal and expects the caller to invoke `clear()` on the merged signal to release them (see nodejs/node#54614 and the Bugbot thread on sanity#14641). get-it is not going to thread a `clear()` call through every request lifecycle, and without it the listeners live as long as the source signal does. So the dependency goes.

## What replaces it

`src/anySignal.ts`, 29 lines, exported as `get-it/any-signal`:

- If `typeof AbortSignal.any === 'function'`, return `AbortSignal.any(signals)`. This is the path Node.js, Bun, Deno, workerd, and Safari 17.4+ take. Native uses weak references and there is nothing to clear.
- Otherwise (Safari 17.0 to 17.3), return a signal from a fresh `AbortController`. If an input is already aborted, abort with the first such input's reason, matching native. Else attach one shared listener to each input; on the first abort, abort with that input's reason and remove the listener from every input.

No `clear` method, no disposable wrapper, no attempt at the Node leak. The fallback only ever runs on old Safari.

Call sites in `src/createRequester.ts` and `src/mock/streamBody.ts` now import `anySignal` from `./anySignal` instead of the package. The new entry is in `package.json` `exports`, `tsconfig.settings.json` `paths`, and the vitest alias, and tsdown builds it to `dist/any-signal.js` with a `.d.ts`. `any-signal` is removed from `dependencies` and the lockfile is back to its pre-#670 state.

README gets a short `get-it/any-signal` example and a row in the entry-points table. The migration guide line gains a clause about the fallback. New `patch` changeset.

### Bundle size

Against 9.5.3 (what `main` is now), `dist/index.min.js` shrinks from 7827 to 7703 bytes, gzip from 3013 to 2980. Against 9.5.2, before any of this, it's +297 bytes minified and +100 gzipped. No runtime dependency added; `undici` remains the only one.

## Tests

`test/any-signal.test.ts` (renamed from `abort-signal-any.test.ts`) keeps the Safari 17 simulation from #670: `beforeEach` shadows `AbortSignal.any` with `undefined` on the platform global, `afterEach` restores the saved descriptor. The same block of cases runs twice, once under the simulation (fallback path) and once with the native static intact (delegation path). Cases cover the ponyfill directly (aborts once with the first aborter's reason, pre-aborted inputs, first-of-several already aborted, inputs left untouched) and the real request paths (caller signal with total and headers timeouts, deadlines still aborting fetch, already-aborted caller signal, `streamFromScript` interruption).

Red check: with the fallback removed so the ponyfill always calls `AbortSignal.any`, 10 of 21 cases fail under the simulation with `TypeError: AbortSignal.any is not a function`. With the fallback, 21 of 21 pass.

## Verification

`pnpm test` on Node 22: 529 passed. `pnpm check` clean. Build and publint clean. happy-dom, jsdom, vercel-edge, react-server, and workerd suites pass. Built-asset smokes on workerd and happy-dom pass. Bun: 529 passed. Deno smoke passes and type-checks `dist`. `node -e "import('get-it/any-signal')"` resolves the new entry through the exports map.

Note: the earlier branch `cursor/any-signal-safari17-39b6` also received this commit before I noticed #670 had merged; that branch is now stale and can be deleted.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db7f7ca3-da7c-40ab-883a-f3e2a35639b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db7f7ca3-da7c-40ab-883a-f3e2a35639b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

